### PR TITLE
Added support for self-exit thread.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ hound = "3.5.0"
 built = { version = "0.6", features = ["chrono", "semver"] }
 crossbeam = "0.8.1"
 base64 = "0.21.0"
-
+notify = "6.0.1"
 
 [build-dependencies]
 built = { version = "0.6", features = ["git2", "chrono", "semver"] }

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -216,7 +216,7 @@ pub fn main() {
         Box::new(hw_specific::version::process),
     );
     if create_retire_thread {
-        let handler = thread::Builder::new().name("ExitPathMonitor".to_string()).spawn(move || { fd_monitor_thread(); });
+        let _handle = thread::Builder::new().name("ExitPathMonitor".to_string()).spawn(move || { fd_monitor_thread(); });
     }
     dab::run(mqtt_host, mqtt_port, handlers);
 }


### PR DESCRIPTION
This change brings a file monitoring thread to control the binary runtime based on a file status.
A systemd path service can start this dab bridge on device but it will not be able to stop it when the file status changes.
The new thread will monitor for existence of /run/dab-enable file and if it gets deleted bridge will self-exit.