### PR TITLE
applications/launch-with-content "parameters" req param is optional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -937,7 +937,7 @@ dependencies = [
 
 [[package]]
 name = "dab-adapter"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-std",
  "base64 0.21.2",

--- a/src/dab/structs.rs
+++ b/src/dab/structs.rs
@@ -404,7 +404,7 @@ pub struct GetApplicationStateResponse {
 pub struct LaunchApplicationWithContentRequest {
     pub appId: String,
     pub contentId: String,
-    pub parameters: Vec<String>,
+    pub parameters: Option<Vec<String>>,
 }
 
 #[allow(non_snake_case)]

--- a/src/device/rdk/applications/launch_with_content.rs
+++ b/src/device/rdk/applications/launch_with_content.rs
@@ -158,8 +158,8 @@ pub fn process(_packet: String) -> Result<String, String> {
         }
     }
 
-    if Dab_Request.parameters.len() > 0 {
-        param_list.append(&mut Dab_Request.parameters);
+    if let Some(mut parameters) = Dab_Request.parameters {
+        param_list.append(&mut parameters);
     }
 
     if is_cobalt {


### PR DESCRIPTION
According to the latest DAB Specification 2.0.