### PR TITLE
adapter: add debug option

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -23,6 +23,9 @@ struct Opt {
     /// To exit based on path file (/run/dab-enable) status.
     #[clap(short, long, value_parser, value_name = "RETIRE")]
     retire: Option<bool>,
+    /// Print RDK messages to stdout
+    #[clap(long, value_parser, value_name = "DEBUG")]
+    debug: Option<bool>,
 }
 
 // The file `built.rs` was placed there by cargo and `build.rs`
@@ -113,6 +116,7 @@ pub fn main() {
     let mqtt_port = opt.port.unwrap_or(1883);
     let device_ip = opt.device.unwrap_or(String::from("localhost"));
     let create_retire_thread = opt.retire.unwrap_or(false);
+    let debug = opt.debug.unwrap_or(false);
 
     if opt.version {
         display_version();
@@ -120,7 +124,7 @@ pub fn main() {
     }
 
     // Initialize the device
-    hw_specific::interface::init(&device_ip);
+    hw_specific::interface::init(&device_ip, debug);
 
     // Register the handlers
     let mut handlers: SharedMap = HashMap::new();

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -7,10 +7,12 @@ use std::fs::File;
 use std::io::Write;
 use surf::Client;
 static mut DEVICE_ADDRESS: String = String::new();
+static mut DEBUG: bool = false;
 
-pub fn init(device_ip: &str) {
+pub fn init(device_ip: &str, debug: bool) {
     unsafe {
         DEVICE_ADDRESS.push_str(&device_ip);
+        DEBUG = debug;
     }
 }
 
@@ -52,6 +54,12 @@ pub fn http_post(json_string: String) -> Result<String, String> {
     let client = Client::new();
     let rdk_address = format!("http://{}:9998/jsonrpc", unsafe { &DEVICE_ADDRESS });
 
+    unsafe {
+        if DEBUG {
+            println!("RDK request: {}", json_string);
+        }
+    }
+
     let response = block_on(async {
         client
             .post(rdk_address)
@@ -64,10 +72,26 @@ pub fn http_post(json_string: String) -> Result<String, String> {
     });
     match response {
         Ok(r) => {
-            return Ok(r.to_string());
+            let str = r.to_string();
+
+            unsafe {
+                if DEBUG {
+                    println!("RDK response: {}", str);
+                }
+            }
+
+            return Ok(str);
         }
         Err(err) => {
-            return Err(err.to_string());
+            let str = err.to_string();
+
+            unsafe {
+                if DEBUG {
+                    println!("RDK error: {}", str);
+                }
+            }
+
+            return Err(str);
         }
     }
 }


### PR DESCRIPTION
Prints RDK messages to stdout. Run as

  cargo run -- -d my-rdk.ddns.net --debug=true