### PR TITLE
RDKDEV-829: Resolve App launch issue via DAB

### DIFF
--- a/src/device/rdk/applications/launch.rs
+++ b/src/device/rdk/applications/launch.rs
@@ -156,6 +156,7 @@ pub fn process(_packet: String) -> Result<String, String> {
             #[derive(Serialize, Clone)]
             struct Param {
                 callsign: String,
+                r#type: String,
                 configuration: CobaltConfig,
             }
             #[derive(Serialize)]
@@ -168,6 +169,7 @@ pub fn process(_packet: String) -> Result<String, String> {
 
             let req_params = Param {
                 callsign: Dab_Request.appId,
+                r#type: "Cobalt".into(),
                 configuration: CobaltConfig {
                     url: format!("https://www.youtube.com/tv?{}", param_list.join("&")),
                 },


### PR DESCRIPTION
Reason for change:
1. YouTube not launching via DAB in container mode. To launch applications that are running in container mode, we need to set "TYPE" parameter in the RDK-Shell launch command so that the ESSOS instance can connect to the correct Display. 

Test Procedure: Refer Ticket
Risks: None
Signed-off by: Vaisakh Anand <vaisakh_anand@comcast.com>