### PR TITLE
Adding support for ListSystemSettings default impl. #12

### DIFF
--- a/src/dab/structs.rs
+++ b/src/dab/structs.rs
@@ -309,9 +309,9 @@ pub struct AudioVolume {
 pub struct ListSystemSettings {
     pub language: Vec<String>,
     pub outputResolution: Vec<OutputResolution>,
-    pub memc: Vec<bool>,
-    pub cec: Vec<bool>,
-    pub lowLatencyMode: Vec<bool>,
+    pub memc: bool,
+    pub cec: bool,
+    pub lowLatencyMode: bool,
     pub matchContentFrameRate: Vec<MatchContentFrameRate>,
     pub hdrOutputMode: Vec<HdrOutputMode>,
     pub pictureMode: Vec<PictureMode>,
@@ -319,8 +319,8 @@ pub struct ListSystemSettings {
     pub audioOutputSource: Vec<AudioOutputSource>,
     pub videoInputSource: Vec<VideoInputSource>,
     pub audioVolume: AudioVolume,
-    pub mute: Vec<bool>,
-    pub textToSpeech: Vec<bool>,
+    pub mute: bool,
+    pub textToSpeech: bool,
 }
 
 #[allow(non_snake_case)]

--- a/src/dab/structs.rs
+++ b/src/dab/structs.rs
@@ -305,7 +305,7 @@ pub struct AudioVolume {
 }
 
 #[allow(non_snake_case)]
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Serialize, Deserialize)]
 pub struct ListSystemSettings {
     pub language: Vec<String>,
     pub outputResolution: Vec<OutputResolution>,
@@ -321,6 +321,99 @@ pub struct ListSystemSettings {
     pub audioVolume: AudioVolume,
     pub mute: bool,
     pub textToSpeech: bool,
+}
+
+// responses from dab-specification-2.0
+impl Default for ListSystemSettings {
+    fn default() -> Self {
+        Self {
+            language: ["en-US".into(), "es".into()].to_vec(),
+            outputResolution: vec![
+                OutputResolution {
+                    width: 1920,
+                    height: 1080,
+                    frequency: 60.0,
+                },
+                OutputResolution {
+                    width: 1920,
+                    height: 1080,
+                    frequency: 50.0,
+                },
+                OutputResolution {
+                    width: 1280,
+                    height: 720,
+                    frequency: 60.0,
+                },
+                OutputResolution {
+                    width: 1280,
+                    height: 720,
+                    frequency: 50.0,
+                },
+                OutputResolution {
+                    width: 720,
+                    height: 576,
+                    frequency: 50.0,
+                },
+                OutputResolution {
+                    width: 640,
+                    height: 480,
+                    frequency: 50.0,
+                },
+            ],
+            memc: false,
+            cec: true,
+            lowLatencyMode: true,
+            matchContentFrameRate: vec![
+                MatchContentFrameRate::EnabledAlways,
+                // MatchContentFrameRate::EnabledSeamlessOnly,
+                MatchContentFrameRate::Disabled,
+            ],
+            hdrOutputMode: vec![
+                HdrOutputMode::AlwaysHdr,
+                HdrOutputMode::HdrOnPlayback,
+                HdrOutputMode::DisableHdr,
+            ],
+            pictureMode: vec![
+                PictureMode::Standard,
+                // PictureMode::Dynamic,
+                // PictureMode::Movie,
+                // PictureMode::Sports,
+                // PictureMode::FilmMaker,
+                // PictureMode::Game,
+                // PictureMode::Auto,
+            ],
+            audioOutputMode: vec![
+                AudioOutputMode::Stereo,
+                AudioOutputMode::MultichannelPcm,
+                AudioOutputMode::PassThrough,
+                AudioOutputMode::Auto,
+            ],
+            audioOutputSource: vec![
+                // AudioOutputSource::NativeSpeaker,
+                // AudioOutputSource::Arc,
+                // AudioOutputSource::EArc,
+                AudioOutputSource::Optical,
+                // AudioOutputSource::Aux,
+                AudioOutputSource::Bluetooth,
+                // AudioOutputSource::Auto,
+                AudioOutputSource::HDMI,
+            ],
+            videoInputSource: vec![
+                VideoInputSource::Tuner,
+                // VideoInputSource::HDMI1,
+                // VideoInputSource::HDMI2,
+                // VideoInputSource::HDMI3,
+                // VideoInputSource::HDMI4,
+                // VideoInputSource::Composite,
+                // VideoInputSource::Component,
+                // VideoInputSource::Home,
+                // VideoInputSource::Cast,
+            ],
+            audioVolume: AudioVolume { min: 0, max: 100 },
+            mute: false,
+            textToSpeech: true,
+        }
+    }
 }
 
 #[allow(non_snake_case)]

--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -86,9 +86,9 @@
 // pub struct ListSystemSettings {
 //     pub language: Vec<String>,
 //     pub outputResolution: Vec<OutputResolution>,
-//     pub memc: Vec<bool>,
-//     pub cec: Vec<bool>,
-//     pub lowLatencyMode: Vec<bool>,
+//     pub memc: bool,
+//     pub cec: bool,
+//     pub lowLatencyMode: bool,
 //     pub matchContentFrameRate: Vec<MatchContentFrameRate>,
 //     pub hdrOutputMode: Vec<HdrOutputMode>,
 //     pub pictureMode: Vec<PictureMode>,
@@ -96,134 +96,22 @@
 //     pub audioOutputSource: Vec<AudioOutputSource>,
 //     pub videoInputSource: Vec<VideoInputSource>,
 //     pub audioVolume: AudioVolume,
-//     pub mute: Vec<bool>,
-//     pub textToSpeech: Vec<bool>,
+//     pub mute: bool,
+//     pub textToSpeech: bool,
 // }
 
 // use super::LANGUAGES;
 // use super::RESOLUTIONS;
-use crate::dab::structs::AudioOutputMode;
-use crate::dab::structs::AudioOutputSource;
-use crate::dab::structs::AudioVolume;
-use crate::dab::structs::HdrOutputMode;
-use crate::dab::structs::ListSystemSettings;
-use crate::dab::structs::MatchContentFrameRate;
-use crate::dab::structs::OutputResolution;
-use crate::dab::structs::PictureMode;
-use crate::dab::structs::VideoInputSource;
+
 use serde_json::json;
+
+use crate::dab::structs::ListSystemSettings;
 
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[allow(unused_mut)]
 pub fn process(_packet: String) -> Result<String, String> {
     let mut ResponseOperator = ListSystemSettings::default();
-    // *** Fill in the fields of the struct ListSystemSettings here ***
-
-    // // Return language tags defined in RFC 5646.
-    // /*
-    //     IMPORTANT NOTE: As defined on the org.rdk.UserPreferences plugin documentation
-    //     (https://rdkcentral.github.io/rdkservices/#/api/UserPreferencesPlugin):
-    //     "The language is written to the /opt/user_preferences.conf file on the device.
-    //     It is the responsibility of the client application to validate the language value and process
-    //     it if required. Any language string that is valid on the client can be set"
-    ResponseOperator.language = vec!["en-US".to_string()];
-
-    ResponseOperator.outputResolution = vec![
-        OutputResolution {
-            width: 1920,
-            height: 1080,
-            frequency: 60.0,
-        },
-        OutputResolution {
-            width: 1920,
-            height: 1080,
-            frequency: 50.0,
-        },
-        OutputResolution {
-            width: 1280,
-            height: 720,
-            frequency: 60.0,
-        },
-        OutputResolution {
-            width: 1280,
-            height: 720,
-            frequency: 50.0,
-        },
-        OutputResolution {
-            width: 720,
-            height: 576,
-            frequency: 50.0,
-        },
-        OutputResolution {
-            width: 640,
-            height: 480,
-            frequency: 50.0,
-        },
-    ];
-
-    ResponseOperator.memc = vec![false, true];
-
-    ResponseOperator.cec = vec![false, true];
-
-    ResponseOperator.lowLatencyMode = vec![false, true];
-
-    ResponseOperator.mute = vec![false, true];
-
-    ResponseOperator.textToSpeech = vec![false, true];
-
-    ResponseOperator.hdrOutputMode = vec![
-        HdrOutputMode::AlwaysHdr,
-        HdrOutputMode::HdrOnPlayback,
-        HdrOutputMode::DisableHdr,
-    ];
-
-    ResponseOperator.audioVolume = AudioVolume { min: 0, max: 100 };
-
-    ResponseOperator.matchContentFrameRate = vec![
-        MatchContentFrameRate::EnabledAlways,
-        // MatchContentFrameRate::EnabledSeamlessOnly,
-        MatchContentFrameRate::Disabled,
-    ];
-
-    ResponseOperator.pictureMode = vec![
-        PictureMode::Standard,
-        // PictureMode::Dynamic,
-        // PictureMode::Movie,
-        // PictureMode::Sports,
-        // PictureMode::FilmMaker,
-        // PictureMode::Game,
-        // PictureMode::Auto,
-    ];
-    ResponseOperator.audioOutputMode = vec![
-        AudioOutputMode::Stereo,
-        AudioOutputMode::MultichannelPcm,
-        AudioOutputMode::PassThrough,
-        AudioOutputMode::Auto,
-    ];
-    ResponseOperator.audioOutputSource = vec![
-        // AudioOutputSource::NativeSpeaker,
-        // AudioOutputSource::Arc,
-        // AudioOutputSource::EArc,
-        AudioOutputSource::Optical,
-        // AudioOutputSource::Aux,
-        AudioOutputSource::Bluetooth,
-        // AudioOutputSource::Auto,
-        AudioOutputSource::HDMI,
-    ];
-    ResponseOperator.videoInputSource = vec![
-        VideoInputSource::Tuner,
-        // VideoInputSource::HDMI1,
-        // VideoInputSource::HDMI2,
-        // VideoInputSource::HDMI3,
-        // VideoInputSource::HDMI4,
-        // VideoInputSource::Composite,
-        // VideoInputSource::Component,
-        // VideoInputSource::Home,
-        // VideoInputSource::Cast,
-    ];
-
-    // *******************************************************************
     let mut ResponseOperator_json = json!(ResponseOperator);
     ResponseOperator_json["status"] = json!(200);
     Ok(serde_json::to_string(&ResponseOperator_json).unwrap())


### PR DESCRIPTION
What :
-------
Adding support for ListSystemSettings default impl.
updated ListSystemSettings{} with dab2.0 specs.

Why :
------
default impl is missing for ListSystemSettings { }.
specs are modified.
getting error in the compliant suit.

How :
------
Added default impl.
Updated object with changes.

Test :
-----
Manually tested.
```
testing system/settings/list   {} ... 
system/settings/list Latency, Expected: 200 ms, Actual: 1 ms

[ PASS ]
```