### PR TITLE
feat : Adding support for movetofront/setfocus.

### DIFF
--- a/src/device/rdk/applications/launch.rs
+++ b/src/device/rdk/applications/launch.rs
@@ -255,6 +255,8 @@ pub fn process(_packet: String) -> Result<String, String> {
             }
             _ => (),
         }
+        //****************org.rdk.RDKShell.moveToFront/setFocus******************************//
+        move_to_front_set_focus(req_params.callsign.clone());
     }
 
     if is_suspended {
@@ -277,10 +279,66 @@ pub fn process(_packet: String) -> Result<String, String> {
             }
             _ => (),
         }
+        //****************org.rdk.RDKShell.moveToFront/setFocus******************************//
+        move_to_front_set_focus(req_params.callsign.clone());
     }
 
     // *******************************************************************
     let mut ResponseOperator_json = json!(ResponseOperator);
     ResponseOperator_json["status"] = json!(200);
     Ok(serde_json::to_string(&ResponseOperator_json).unwrap())
+}
+
+pub fn move_to_front_set_focus(callsign: String) {
+    //****************org.rdk.RDKShell.moveToFront/setFocus******************************//
+
+    // RDK Request Common Structs
+    #[derive(Serialize, Clone)]
+    struct RequestParams {
+        client: String,
+        callsign: String,
+    }
+
+    #[derive(Serialize)]
+    struct RdkRequest {
+        jsonrpc: String,
+        id: i32,
+        method: String,
+        params: RequestParams,
+    }
+
+    let req_params = RequestParams {
+        client: callsign.clone(),
+        callsign: callsign.clone(),
+    };
+    let request = RdkRequest {
+        jsonrpc: "2.0".into(),
+        id: 3,
+        method: "org.rdk.RDKShell.moveToFront".into(),
+        params: req_params.clone(),
+    };
+    let json_string = serde_json::to_string(&request).unwrap();
+    let response_json = http_post(json_string);
+
+    match response_json {
+        Err(err) => {
+            println!("moveToFront ERROR Erro: {}", err);
+        }
+        _ => (),
+    }
+    let request = RdkRequest {
+        jsonrpc: "2.0".into(),
+        id: 3,
+        method: "org.rdk.RDKShell.1.setFocus".into(),
+        params: req_params.clone(),
+    };
+    let json_string = serde_json::to_string(&request).unwrap();
+    let response_json = http_post(json_string);
+
+    match response_json {
+        Err(err) => {
+            println!("SetFocus ERROR Erro: {}", err);
+        }
+        _ => (),
+    }
 }


### PR DESCRIPTION
What
------------------------------------------------------------------
fix for moving app to front from from suspended mode and second launch. 
fixing deeplink issue in launch-with-content.

Why
-----------------------------------------------------------------------------
Not able to see app on screen when launching from suspended mode/second time

How
----------------------------------------------------------------------------
Call movetofront/setfocus api call to move app to front on display

Test
-------------------------------------------------------------------------------
```
Tested scenarios:

1. ApplicationsLaunchConformance --->InputLongKeyPressKeyHome--->ApplicationsLaunchConformance
    -------------> Launched----->Able to navigate
2. ApplicationsLaunchConformance--->InputLongKeyPressKeyHome--->ApplicationsLaunchWithParameters
    -------------->Launched with parameter(playback)--->Able to navigate
3. ApplicationsLaunchConformance --->launch amazon using controllerUI--->ApplicationsLaunchConformance
    -------------->Launched----->Able to navigate
4. ApplicationsLaunchConformance----> ApplicationsLaunchWithParameters
    -------------->Launched----->Launched for second time with content
5. ApplicationsLaunchWithContentConformance->InputLongKeyPressKeyHome->ApplicationsLaunchWithContentConformance
```
```
sam2@sam2-VirtualBox:~/RUST/dab-compliance-suite$ python3 main.py -v -b 127.0.0.1 -I 02AD320123DA -c ApplicationsLaunchConformance
testing applications/launch   {"appId": "YouTube"} ... App started?(Y/N)
[y]
applications/launch Latency, Expected: 10000 ms, Actual: 390 ms
[ PASS ]
{
  "status": 200
}
```