### PR TITLE
Added support for voice/list

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -210,6 +210,10 @@ pub fn main() {
         Box::new(hw_specific::health_check::get::process),
     );
     handlers.insert(
+        "voice/list".to_string(),
+        Box::new(hw_specific::voice::list::process),
+    );
+    handlers.insert(
         "voice/send-audio".to_string(),
         Box::new(hw_specific::voice::send_audio::process),
     );

--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -214,6 +214,10 @@ pub fn main() {
         Box::new(hw_specific::voice::list::process),
     );
     handlers.insert(
+        "voice/set".to_string(),
+        Box::new(hw_specific::voice::set::process),
+    );
+    handlers.insert(
         "voice/send-audio".to_string(),
         Box::new(hw_specific::voice::send_audio::process),
     );

--- a/src/dab/structs.rs
+++ b/src/dab/structs.rs
@@ -200,6 +200,12 @@ pub struct VoiceListRequest {}
 
 #[allow(non_snake_case)]
 #[derive(Default, Serialize, Deserialize)]
+pub struct ListVoiceSystemsResponse {
+    pub voiceSystems: Vec<VoiceSystem>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct VoiceSystem {
     pub name: String,
     pub enabled: bool,

--- a/src/device/rdk/operations/list.rs
+++ b/src/device/rdk/operations/list.rs
@@ -76,7 +76,7 @@ pub fn process(_packet: String) -> Result<String, String> {
     ResponseOperator
         .operations
         .push("health-check/get".to_string());
-    // ResponseOperator.operations.push("voice/list".to_string());
+    ResponseOperator.operations.push("voice/list".to_string());
     // ResponseOperator.operations.push("voice/set".to_string());
     // ResponseOperator
     //     .operations

--- a/src/device/rdk/voice/set.rs
+++ b/src/device/rdk/voice/set.rs
@@ -15,8 +15,7 @@ use crate::dab::structs::ErrorResponse;
 #[allow(unused_imports)]
 use crate::dab::structs::SetVoiceSystemRequest;
 use crate::dab::structs::SetVoiceSystemResponse;
-use crate::device::rdk::interface::http_post;
-use serde::{Deserialize, Serialize};
+use super::voice_functions::configureVoice;
 use serde_json::json;
 
 #[allow(non_snake_case)]
@@ -24,50 +23,57 @@ use serde_json::json;
 #[allow(unused_mut)]
 pub fn process(_packet: String) -> Result<String, String> {
     let mut ResponseOperator = SetVoiceSystemResponse::default();
-    // *** Fill in the fields of the struct SetVoiceSystemResponse here ***
+    // *** parse and call configureVoice(arg)
+    let IncomingMessage = serde_json::from_str(&_packet);
 
-    #[derive(Serialize)]
-    struct RdkRequest {
-        jsonrpc: String,
-        id: i32,
-        method: String,
-        params: String,
-    }
-
-    let request = RdkRequest {
-        jsonrpc: "2.0".into(),
-        id: 3,
-        method: "org.rdk.DisplaySettings.getConnectedVideoDisplays".into(),
-        params: "{}".into(),
-    };
-
-    #[derive(Deserialize)]
-    struct RdkResponse {
-        jsonrpc: String,
-        id: i32,
-        result: GetConnectedVideoDisplaysResult,
-    }
-
-    #[derive(Deserialize)]
-    struct GetConnectedVideoDisplaysResult {
-        connectedVideoDisplays: Vec<String>,
-        success: bool,
-    }
-
-    let json_string = serde_json::to_string(&request).unwrap();
-    let response_json = http_post(json_string);
-
-    match response_json {
-        Ok(val2) => {
-            let _rdkresponse: RdkResponse = serde_json::from_str(&val2).unwrap();
-        }
-
+    match IncomingMessage {
         Err(err) => {
-            println!("Erro: {}", err);
-
-            return Err(err);
+            let response = ErrorResponse {
+                status: 400,
+                error: "Setting voiceSystem failed: argument parse failure.".to_string() + err.to_string().as_str(),
+            };
+            let Response_json = json!(response);
+            return Err(serde_json::to_string(&Response_json).unwrap());
         }
+        Ok(_) => (),
     }
+
+    let Voice_Set_Request: SetVoiceSystemRequest = IncomingMessage.unwrap();
+
+    if Voice_Set_Request.voiceSystem.name.is_empty() {
+        let response = ErrorResponse {
+            status: 400,
+            error: "request missing parameter(s)".to_string(),
+        };
+        let Response_json = json!(response);
+        return Err(serde_json::to_string(&Response_json).unwrap());
+    }
+
+    // TODO: Add other RDK specific voice protocol support confirmation.
+    if Voice_Set_Request.voiceSystem.name != "AmazonAlexa" {
+        // Unsupported VoiceSystem.
+        let response = ErrorResponse {
+            status: 400,
+            error: "Unsupported voiceSystem(".to_string(),
+        };
+        let Response_json = json!(response);
+        return Err(serde_json::to_string(&Response_json).unwrap());
+    }
+
+    configureVoice(Voice_Set_Request.voiceSystem.enabled)?;
+    // TODO: validation of response.
+    // if response.success == false {
+    //     // Thunder JSONRPC failed
+    //     let response = ErrorResponse {
+    //         status: 400,
+    //         error: "Platform operation failed.".to_string(),
+    //     };
+    //     let Response_json = json!(response);
+    //     return Err(serde_json::to_string(&Response_json).unwrap());
+    // }
+
+    ResponseOperator.voiceSystem.enabled = true;
+    ResponseOperator.voiceSystem.name = Voice_Set_Request.voiceSystem.name;
 
     // *******************************************************************
     let mut ResponseOperator_json = json!(ResponseOperator);

--- a/src/device/rdk/voice/voice_functions.rs
+++ b/src/device/rdk/voice/voice_functions.rs
@@ -121,6 +121,28 @@ pub fn encode_adpcm(samples: &[i16]) -> Vec<u8> {
     adpcm_data
 }
 
+// fn enable_voice(EnableVoice: bool) -> Result<(), RdkResponseSimple> {
+//    #[derive(Serialize)]
+//    struct Ptt {
+//        enable: bool,
+//    }
+//
+//    #[derive(Serialize)]
+//    struct Param {
+//        ptt: Ptt,
+//        enable: bool,
+//    }
+//
+//    let req_params = Param {
+//        enable: EnableVoice,
+//        ptt: Ptt { enable: true },
+//    };
+//
+//    let _rdkresponse: RdkResponseSimple = rdk_request_with_params ("org.rdk.VoiceControl.configureVoice", req_params)?;
+//
+//    Ok(())
+//}
+
 fn enable_ptt() -> Result<(), String> {
     #[derive(Serialize)]
     struct Ptt {

--- a/src/device/rdk/voice/voice_functions.rs
+++ b/src/device/rdk/voice/voice_functions.rs
@@ -121,27 +121,28 @@ pub fn encode_adpcm(samples: &[i16]) -> Vec<u8> {
     adpcm_data
 }
 
-// fn enable_voice(EnableVoice: bool) -> Result<(), RdkResponseSimple> {
-//    #[derive(Serialize)]
-//    struct Ptt {
-//        enable: bool,
-//    }
-//
-//    #[derive(Serialize)]
-//    struct Param {
-//        ptt: Ptt,
-//        enable: bool,
-//    }
-//
-//    let req_params = Param {
-//        enable: EnableVoice,
-//        ptt: Ptt { enable: true },
-//    };
-//
-//    let _rdkresponse: RdkResponseSimple = rdk_request_with_params ("org.rdk.VoiceControl.configureVoice", req_params)?;
-//
-//    Ok(())
-//}
+#[allow(non_snake_case)]
+pub fn configureVoice(EnableVoice: bool) -> Result<(), String> {
+   #[derive(Serialize)]
+   struct Ptt {
+       enable: bool,
+   }
+
+   #[derive(Serialize)]
+   struct Param {
+       ptt: Ptt,
+       enable: bool,
+   }
+
+   let req_params = Param {
+       enable: EnableVoice,
+       ptt: Ptt { enable: EnableVoice },
+   };
+
+   let _rdkresponse: RdkResponseSimple = rdk_request_with_params ("org.rdk.VoiceControl.configureVoice", req_params)?;
+
+   Ok(())
+}
 
 fn enable_ptt() -> Result<(), String> {
     #[derive(Serialize)]


### PR DESCRIPTION
We were getting _501_ error while executing compliance test _VoiceListConformance_ without this change. 
With this change compliance test is passing with 200; below response from AH212 RDK Reference device:
```
$ python3 main.py -v -b <deviceIP> -I <deviceID> -c VoiceListConformance

testing voice/list   {} ... 
voice/list Latency, Expected: 200 ms, Actual: 73 ms
[ PASS ]
{
  "status": 200,
  "voiceSystems": [
    {
      "enabled": true,
      "name": "AmazonAlexa"
    }
  ]
}
```


