### PR TITLE
Added support for voice/list

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -210,6 +210,10 @@ pub fn main() {
         Box::new(hw_specific::health_check::get::process),
     );
     handlers.insert(
+        "voice/list".to_string(),
+        Box::new(hw_specific::voice::list::process),
+    );
+    handlers.insert(
         "voice/send-audio".to_string(),
         Box::new(hw_specific::voice::send_audio::process),
     );

--- a/src/dab/structs.rs
+++ b/src/dab/structs.rs
@@ -200,6 +200,12 @@ pub struct VoiceListRequest {}
 
 #[allow(non_snake_case)]
 #[derive(Default, Serialize, Deserialize)]
+pub struct ListVoiceSystemsResponse {
+    pub voiceSystems: Vec<VoiceSystem>,
+}
+
+#[allow(non_snake_case)]
+#[derive(Default, Serialize, Deserialize)]
 pub struct VoiceSystem {
     pub name: String,
     pub enabled: bool,

--- a/src/device/rdk/operations/list.rs
+++ b/src/device/rdk/operations/list.rs
@@ -76,7 +76,7 @@ pub fn process(_packet: String) -> Result<String, String> {
     ResponseOperator
         .operations
         .push("health-check/get".to_string());
-    // ResponseOperator.operations.push("voice/list".to_string());
+    ResponseOperator.operations.push("voice/list".to_string());
     // ResponseOperator.operations.push("voice/set".to_string());
     // ResponseOperator
     //     .operations

--- a/src/device/rdk/voice/voice_functions.rs
+++ b/src/device/rdk/voice/voice_functions.rs
@@ -121,6 +121,28 @@ pub fn encode_adpcm(samples: &[i16]) -> Vec<u8> {
     adpcm_data
 }
 
+// fn enable_voice(EnableVoice: bool) -> Result<(), RdkResponseSimple> {
+//    #[derive(Serialize)]
+//    struct Ptt {
+//        enable: bool,
+//    }
+//
+//    #[derive(Serialize)]
+//    struct Param {
+//        ptt: Ptt,
+//        enable: bool,
+//    }
+//
+//    let req_params = Param {
+//        enable: EnableVoice,
+//        ptt: Ptt { enable: true },
+//    };
+//
+//    let _rdkresponse: RdkResponseSimple = rdk_request_with_params ("org.rdk.VoiceControl.configureVoice", req_params)?;
+//
+//    Ok(())
+//}
+
 fn enable_ptt() -> Result<(), String> {
     #[derive(Serialize)]
     struct Ptt {


### PR DESCRIPTION
We were getting 501 error while executing compliance test VoiceListConformance without this change.
With this change compliance test is passing with 200; below response from AH212 RDK Reference device:
```
$ python3 main.py -v -b <deviceIP> -I <deviceID> -c VoiceListConformance

testing voice/list   {} ... 
voice/list Latency, Expected: 200 ms, Actual: 73 ms
[ PASS ]
{
  "status": 200,
  "voiceSystems": [
    {
      "enabled": true,
      "name": "AmazonAlexa"
    }
  ]
}
```