### PR TITLE
Update device id in device/info, videoInputSource to HOME in system/settings/get (considering STB mode) and retire path from /run to /opt. 

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -20,7 +20,7 @@ struct Opt {
     /// Print the version information
     #[clap(short, long, value_parser, value_name = "VERSION")]
     version: bool,
-    /// To exit based on path file (/run/dab-enable) status.
+    /// To exit based on path file (/opt/dab-enable) status.
     #[clap(short, long, value_parser, value_name = "RETIRE")]
     retire: Option<bool>,
     /// Print RDK messages to stdout
@@ -39,7 +39,7 @@ fn fd_monitor_thread() {
     use std::process;
     use std::time::Duration;
 
-    static MONITORPATH: &str = "/run";
+    static MONITORPATH: &str = "/opt";
     println!("Monitoring changes of {}/dab-enable", MONITORPATH);
     let monitor_path = Path::new(MONITORPATH);
 

--- a/src/dab.rs
+++ b/src/dab.rs
@@ -25,6 +25,7 @@ use device_telemetry::DeviceTelemetry;
 pub fn run(mqtt_server: String, mqtt_port: u16, mut function_map: SharedMap) {
     // Get the device ID
     let device_id = hw_specific::interface::get_device_id();
+    println!("DAB Device ID: {}", device_id);
 
     // Connect to the MQTT broker
     let mut mqtt_client = MqttClient::new(mqtt_server, mqtt_port);

--- a/src/device/rdk/device/info.rs
+++ b/src/device/rdk/device/info.rs
@@ -52,6 +52,7 @@ use crate::dab::structs::GetDeviceInformationResponse;
 use crate::dab::structs::NetworkInterface;
 use crate::dab::structs::NetworkInterfaceType;
 use crate::device::rdk::interface::http_post;
+use crate::device::rdk::interface::get_device_id;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -442,6 +443,7 @@ pub fn process(_packet: String) -> Result<String, String> {
     ResponseOperator.chipset = Deviceidentification.result.chipset;
     ResponseOperator.screenWidthPixels = ScreenResolution.result.w;
     ResponseOperator.screenHeightPixels = ScreenResolution.result.h;
+    ResponseOperator.deviceId = get_device_id();
 
     if ConnectedVideoDisplays.result.connectedVideoDisplays[0].contains("HDMI") {
         ResponseOperator.displayType = DisplayType::External;

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -25,7 +25,6 @@ pub fn get_device_id() -> String {
             let response: serde_json::Value = serde_json::from_str(&r).unwrap();
             let device_id = response["result"]["estb_mac"].as_str().unwrap();
             let dab_device_id = device_id.replace(":", "").to_string();
-            println!("DAB Device ID: {}", dab_device_id);
             return dab_device_id;
         }
         Err(err) => {

--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -307,8 +307,8 @@ pub fn process(_packet: String) -> Result<String, String> {
         // VideoInputSource::HDMI4,
         // VideoInputSource::Composite,
         // VideoInputSource::Component,
-        // VideoInputSource::Home,
-        VideoInputSource::Cast,
+        VideoInputSource::Home,
+        // VideoInputSource::Cast,
     ];
 
     // *******************************************************************


### PR DESCRIPTION
```
$ dabSingleTest DeviceInfoConformance
testing device/info   {} ... 

device/info Latency, Expected: 200 ms, Actual: 1243 ms
device/info took more time than expected.

[ FAILED ]

{
  "chipset": "Amlogic S905X4",
  "deviceId": "487E489392DC",
  "displayType": "External",
  "firmwareBuild": "lib32-skyworth-generic-mediaclient-image_FBT_rdk-next_20231206080332",
  "firmwareVersion": "MESONSC2-LIB32-AH212-HP44H-RDK/AML_SDK-BSP1019-RDK5.1.0-WPE_R4-NONB12-RW#SPIN=0",
  "manufacturer": "Skyworth",
  "model": "HP44H",
  "networkInterfaces": [
    {
      "connected": false,
      "dns": [],
      "ipAddress": "",
      "macAddress": "02:ad:32:01:a8:56",
      "type": "Ethernet"
    },
    {
      "connected": true,
      "dns": [],
      "ipAddress": "2601:41:c300:1bc0:4a7e:48ff:fe93:92dc",
      "macAddress": "48:7e:48:93:92:dc",
      "type": "Wifi"
    }
  ],
  "screenHeightPixels": 1080,
  "screenWidthPixels": 1920,
  "serialNumber": "",
  "status": 200,
  "uptimeSince": 5175
}

$ dabSingleTest SystemSettingsGetConformance
testing system/settings/get   {} ... 

system/settings/get Latency, Expected: 200 ms, Actual: 119 ms

[ PASS ]

{
  "audioOutputMode": "Auto",
  "audioOutputSource": "HDMI",
  "audioVolume": 20,
  "cec": true,
  "hdrOutputMode": "AlwaysHdr",
  "language": "en-US",
  "lowLatencyMode": false,
  "matchContentFrameRate": "Disabled",
  "memc": false,
  "mute": false,
  "outputResolution": {
    "frequency": 60.0,
    "height": 1080,
    "width": 1920
  },
  "pictureMode": "Standard",
  "status": 200,
  "textToSpeech": false,
  "videoInputSource": "Home"
}
```