### PR TITLE
feat: Adding support to read keycode input from user file

### DIFF
--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -1,9 +1,10 @@
 use crate::dab::structs::{AudioOutputMode, ErrorResponse};
 use futures::executor::block_on;
 use lazy_static::lazy_static;
-use serde::{Deserialize, de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fs::File;
+use std::io::Read;
 use std::io::Write;
 use surf::Client;
 static mut DEVICE_ADDRESS: String = String::new();
@@ -157,10 +158,13 @@ pub fn rdk_request<R: DeserializeOwned>(method: &str) -> Result<R, String> {
     #[derive(Serialize)]
     struct RdkNullParams {}
 
-    rdk_request_with_params(method,RdkNullParams {})
+    rdk_request_with_params(method, RdkNullParams {})
 }
 
-pub fn rdk_request_with_params<P: Serialize, R: DeserializeOwned>(method: &str, params: P) -> Result<R, String> {
+pub fn rdk_request_with_params<P: Serialize, R: DeserializeOwned>(
+    method: &str,
+    params: P,
+) -> Result<R, String> {
     #[derive(Serialize)]
     struct RdkRequest<P> {
         jsonrpc: String,
@@ -296,6 +300,14 @@ lazy_static! {
         // keycode_map.insert(String::from("KEY_GREEN"),0);
         // keycode_map.insert(String::from("KEY_YELLOW"),0);
         // keycode_map.insert(String::from("KEY_BLUE"),0);
+        //Input/Overwrite keys using inputs from keymapping.json file
+        if let Ok(json_file) = read_keymap_json("/etc/keymapping.json") {
+            if let Ok(new_keymap) = serde_json::from_str::<HashMap<String, u16>>(&json_file) {
+                for (key, value) in new_keymap {
+                    keycode_map.insert(key, value);
+                }
+            }
+        }
         keycode_map
     };
 }
@@ -334,4 +346,21 @@ pub fn rdk_sound_mode_to_dab(mode: &String) -> Option<AudioOutputMode> {
 
 pub fn get_device_memory() -> Result<u32, String> {
     Ok(0)
+}
+
+//Read key inputs from file
+
+pub fn read_keymap_json(file_path: &str) -> Result<String, String> {
+    let mut file_content = String::new();
+    File::open(file_path)
+        .map_err(|e| {
+            println!("Error opening file: {}", e);
+            e.to_string()
+        })?
+        .read_to_string(&mut file_content)
+        .map_err(|e| {
+            println!("Error reading file: {}", e);
+            e.to_string()
+        })?;
+    Ok(file_content)
 }


### PR DESCRIPTION
What
--------------------------------------------------------------------
Adding support to read keys from json file and insert/overwrite on top of existing keycodes .

Why
-------------------------------------------------------------------
Currently the keycodes are hardcoded in interface.rs, adding support for user to add platform specific keycodes

How
----------------------------------------------------------------------
Added support to add user specific keycodes, read from the file and populate (insert/overwrite) keycode hashmap


