### PR TITLE
Filtered applications/list to include only DAB-2.0 listed AppIDs.

### DIFF
--- a/src/device/rdk/applications/list.rs
+++ b/src/device/rdk/applications/list.rs
@@ -64,8 +64,27 @@ pub fn process(_packet: String) -> Result<String, String> {
         Ok(val2) => {
             let rdkresponse: RdkResponse = serde_json::from_str(&val2).unwrap();
             for s in rdkresponse.result.types.iter() {
-                let app = Application { appId: s.clone() };
-                ResponseOperator.applications.push(app);
+                match s.as_str() {
+                    "YouTube" => {
+                        let app = Application {
+                            appId: ("YouTube").to_string(),
+                        };
+                        ResponseOperator.applications.push(app);
+                    }
+                    "Amazon" => {
+                        let app = Application {
+                            appId: ("PrimeVideo").to_string(),
+                        };
+                        ResponseOperator.applications.push(app);
+                    }
+                    "Netflix" => {
+                        let app = Application {
+                            appId: ("Netflix").to_string(),
+                        };
+                        ResponseOperator.applications.push(app);
+                    }
+                    &_ => println!("Out of scope of DAB2.0 Spec."),
+                }
             }
         }
 


### PR DESCRIPTION
```
$ python3 main.py -v -b DeviceIP -I DeviceID -c ApplicationsListConformance

testing applications/list   {} ... 
applications/list Latency, Expected: 200 ms, Actual: 59 ms

[ PASS ]

{
  "applications": [
    {
      "appId": "PrimeVideo"
    },
    {
      "appId": "YouTube"
    }
  ],
  "status": 200
}
```