### PR TITLE
fix: decode encoded parameters for youtube playback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -961,6 +961,7 @@ dependencies = [
  "tokio",
  "tts_rust",
  "tungstenite",
+ "urlencoding",
 ]
 
 [[package]]
@@ -4023,6 +4024,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf-8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ built = { version = "0.6", features = ["chrono", "semver"] }
 crossbeam = "0.8.1"
 base64 = "0.21.0"
 notify = "6.0.1"
+urlencoding = "2.0.0"
 
 [build-dependencies]
 built = { version = "0.6", features = ["git2", "chrono", "semver"] }

--- a/src/device/rdk/applications/launch.rs
+++ b/src/device/rdk/applications/launch.rs
@@ -15,6 +15,7 @@ use crate::dab::structs::LaunchApplicationResponse;
 use crate::device::rdk::interface::http_post;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use urlencoding::decode;
 
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -142,6 +143,12 @@ pub fn process(_packet: String) -> Result<String, String> {
     let mut param_list = vec![];
     if let Some(mut parameters) = Dab_Request.parameters.clone() {
         if parameters.len() > 0 {
+            if is_cobalt {
+                // Decode each parameter before appending to the list
+                for param in &mut parameters {
+                    *param = decode(param).unwrap().to_string();
+                }
+            }
             param_list.append(&mut parameters);
         }
     }

--- a/src/device/rdk/applications/launch_with_content.rs
+++ b/src/device/rdk/applications/launch_with_content.rs
@@ -16,6 +16,7 @@ use crate::dab::structs::LaunchApplicationWithContentResponse;
 use crate::device::rdk::interface::http_post;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
+use urlencoding::decode;
 
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -161,6 +162,12 @@ pub fn process(_packet: String) -> Result<String, String> {
     }
 
     if let Some(mut parameters) = Dab_Request.parameters {
+        if is_cobalt {
+            // Decode each parameter before appending to the list
+            for param in &mut parameters {
+                *param = decode(param).unwrap().to_string();
+            }
+        }
         param_list.append(&mut parameters);
     }
 


### PR DESCRIPTION
What
----------------------------------------------------------
Adding fix to decode encoded parameters for youtube

Why
-----------------------------------------------------------------
As per dab-specification encoded url is given as parameter to youtube, but youtube accepts parameters in decoded string format

How
---------------------------------------------------------------
using urlencoding crate decoded the incoming parameter list for youtube before appening the parameter list