### PR TITLE
Added some support logs.

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -121,6 +121,8 @@ pub fn main() {
     if opt.version {
         display_version();
         return;
+    } else if let Some(hash) = built_info::GIT_COMMIT_HASH {
+        println!("DAB<->RDK Adapter [HASH {}]", hash);
     }
 
     // Initialize the device

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -310,7 +310,7 @@ lazy_static! {
         //     "KEY_MENU":408
         // }
             if let Ok(new_keymap) = serde_json::from_str::<HashMap<String, u16>>(&json_file) {
-                println!("Imported platform specified keymap /opt/dab_platform_keymap.json.")
+                println!("Imported platform specified keymap /opt/dab_platform_keymap.json.");
                 for (key, value) in new_keymap {
                     keycode_map.insert(key, value);
                 }

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -308,8 +308,9 @@ lazy_static! {
         //     "KEY_CHANNEL_UP":104,
         //     "KEY_CHANNEL_DOWN":109,
         //     "KEY_MENU":408
-        // } 
+        // }
             if let Ok(new_keymap) = serde_json::from_str::<HashMap<String, u16>>(&json_file) {
+                println!("Imported platform specified keymap /opt/dab_platform_keymap.json.")
                 for (key, value) in new_keymap {
                     keycode_map.insert(key, value);
                 }


### PR DESCRIPTION
This change helps debugging on error or abnormal behaviors from the log file itself instead of comparing the specific device stack/build.

- Added SHA print into log when the runtime starts which can be used to identify the build version from log.
- Added log to notify when any platform specific keymap override is detected.