### PR TITLE
Added some support logs.

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -121,6 +121,8 @@ pub fn main() {
     if opt.version {
         display_version();
         return;
+    } else if let Some(hash) = built_info::GIT_COMMIT_HASH {
+        println!("DAB<->RDK Adapter [{}]", hash);
     }
 
     // Initialize the device

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -308,8 +308,9 @@ lazy_static! {
         //     "KEY_CHANNEL_UP":104,
         //     "KEY_CHANNEL_DOWN":109,
         //     "KEY_MENU":408
-        // } 
+        // }
             if let Ok(new_keymap) = serde_json::from_str::<HashMap<String, u16>>(&json_file) {
+                println!("Imported platform specified keymap /opt/dab_platform_keymap.json.");
                 for (key, value) in new_keymap {
                     keycode_map.insert(key, value);
                 }
@@ -361,12 +362,14 @@ pub fn read_keymap_json(file_path: &str) -> Result<String, String> {
     let mut file_content = String::new();
     File::open(file_path)
         .map_err(|e| {
-            println!("Error opening file: {}", e);
+            if e.kind() != std::io::ErrorKind::NotFound {
+                println!("Error opening {}: {}", file_path, e);
+            }
             e.to_string()
         })?
         .read_to_string(&mut file_content)
         .map_err(|e| {
-            println!("Error reading file: {}", e);
+            println!("Error reading {}: {}", file_path, e);
             e.to_string()
         })?;
     Ok(file_content)


### PR DESCRIPTION
This change helps debugging on error or abnormal behaviors from the log file itself instead of comparing the specific device stack/build.

- Added SHA print into log when the runtime starts which can be used to identify the build version from log.
- Added log to notify when any platform specific keymap override is detected.

**No platform keymap file**
```
Dec 15 02:58:06 AmlogicFirebolt systemd[1]: Started DAB <-> RDK adapter.
Dec 15 02:58:06 AmlogicFirebolt dab-adapter[24658]: DAB<->RDK Adapter [6f69b08b5ddc81b2df40f77147a01a91b396a6bd]
Dec 15 02:58:06 AmlogicFirebolt dab-adapter[24658]: Monitoring changes of /opt/dab-enable
Dec 15 02:58:07 AmlogicFirebolt dab-adapter[24658]: DAB Device ID: A09DC16EB2C6
Dec 15 02:58:07 AmlogicFirebolt dab-adapter[24658]: Ready to process DAB requests
Dec 15 02:58:22 AmlogicFirebolt dab-adapter[24658]: OK: input/key/list
```
**With platform keymap file**
```
Dec 15 02:59:28 AmlogicFirebolt systemd[1]: Started DAB <-> RDK adapter.
Dec 15 02:59:28 AmlogicFirebolt dab-adapter[27995]: DAB<->RDK Adapter [6f69b08b5ddc81b2df40f77147a01a91b396a6bd]
Dec 15 02:59:28 AmlogicFirebolt dab-adapter[27995]: Monitoring changes of /opt/dab-enable
Dec 15 02:59:29 AmlogicFirebolt dab-adapter[27995]: DAB Device ID: A09DC16EB2C6
Dec 15 02:59:29 AmlogicFirebolt dab-adapter[27995]: Ready to process DAB requests
Dec 15 02:59:34 AmlogicFirebolt dab-adapter[27995]: OK: input/key/list
Dec 15 02:59:34 AmlogicFirebolt dab-adapter[27995]: Imported platform specified keymap /opt/dab_platform_keymap.json.
Dec 15 03:00:06 AmlogicFirebolt dab-adapter[27995]: OK: input/key/list
```