### PR TITLE
WIP: Audio fmtconv on mismatch

### DIFF
--- a/src/adapter.rs
+++ b/src/adapter.rs
@@ -121,6 +121,8 @@ pub fn main() {
     if opt.version {
         display_version();
         return;
+    } else if let Some(hash) = built_info::GIT_COMMIT_HASH {
+        println!("DAB<->RDK Adapter [{}]", hash);
     }
 
     // Initialize the device

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -308,8 +308,9 @@ lazy_static! {
         //     "KEY_CHANNEL_UP":104,
         //     "KEY_CHANNEL_DOWN":109,
         //     "KEY_MENU":408
-        // } 
+        // }
             if let Ok(new_keymap) = serde_json::from_str::<HashMap<String, u16>>(&json_file) {
+                println!("Imported platform specified keymap /opt/dab_platform_keymap.json.");
                 for (key, value) in new_keymap {
                     keycode_map.insert(key, value);
                 }
@@ -361,12 +362,14 @@ pub fn read_keymap_json(file_path: &str) -> Result<String, String> {
     let mut file_content = String::new();
     File::open(file_path)
         .map_err(|e| {
-            println!("Error opening file: {}", e);
+            if e.kind() != std::io::ErrorKind::NotFound {
+                println!("Error opening {}: {}", file_path, e);
+            }
             e.to_string()
         })?
         .read_to_string(&mut file_content)
         .map_err(|e| {
-            println!("Error reading file: {}", e);
+            println!("Error reading {}: {}", file_path, e);
             e.to_string()
         })?;
     Ok(file_content)

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -34,14 +34,16 @@ pub fn get_device_id() -> String {
     }
 }
 
-pub fn http_download(url: String) -> Result<(), String> {
+pub fn http_download(url: String, mut file_name: String) -> Result<(), String> {
     let client = Client::new();
-
+    if file_name.is_empty() {
+        file_name = "/tmp/tts.wav".into();
+    }
     let response = block_on(async { client.get(url).await });
 
     match response {
         Ok(mut r) => {
-            let mut file = File::create("/tmp/tts.wav").unwrap();
+            let mut file = File::create(file_name).unwrap();
             let body = block_on(r.body_bytes()).unwrap();
             file.write_all(&body).unwrap();
             return Ok(());

--- a/src/device/rdk/voice/send_audio.rs
+++ b/src/device/rdk/voice/send_audio.rs
@@ -65,7 +65,7 @@ pub fn process(packet: String) -> Result<String, String> {
                             Err(err) => {
                                 let response = ErrorResponse {
                                     status: 400,
-                                    error: err,
+                                    error: err.to_string(),
                                 };
                                 let Response_json = json!(response);
                                 return Err(serde_json::to_string(&Response_json).unwrap());

--- a/src/device/rdk/voice/send_audio.rs
+++ b/src/device/rdk/voice/send_audio.rs
@@ -43,13 +43,16 @@ pub fn process(packet: String) -> Result<String, String> {
                 let Response_json = json!(response);
                 return Err(serde_json::to_string(&Response_json).unwrap());
             }
-            let result = http_download(DabRequest.fileLocation, "/tmp/tts.wav".into());
+            let result = http_download(DabRequest.fileLocation, "/tmp/tts-download.wav".into());
             match result {
                 Ok(_) => {
                     // RDK Currently supports PCM S16LE 16K 256kbps. Convert on mismatch.
-                    if !is_supported_audio_format("/tmp/tts.wav".into()) {
+                    if !is_supported_audio_format("/tmp/tts-download.wav".into()) {
                         println!("Calling convert_audio_to_pcms16le16mono");
-                        convert_audio_to_pcms16le16mono("/tmp/tts.wav".into());
+                        convert_audio_to_pcms16le16mono(
+                            "/tmp/tts-download.wav".into(),
+                            "/tmp/tts.wav".into(),
+                        );
                     }
                 }
                 Err(e) => {

--- a/src/device/rdk/voice/send_audio.rs
+++ b/src/device/rdk/voice/send_audio.rs
@@ -17,6 +17,12 @@ use super::voice_functions::convert_audio_to_pcms16le16mono;
 use super::voice_functions::is_supported_audio_format;
 use super::voice_functions::sendVoiceCommand;
 use crate::device::rdk::interface::http_download;
+use std::fs;
+
+fn rename_file(source_path: &str, target_path: &str) -> Result<(), std::io::Error> {
+    fs::rename(source_path, target_path)?;
+    Ok(())
+}
 
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -53,6 +59,18 @@ pub fn process(packet: String) -> Result<String, String> {
                             "/tmp/tts-download.wav".into(),
                             "/tmp/tts.wav".into(),
                         );
+                    } else {
+                        match rename_file("/tmp/tts-download.wav".into(), "/tmp/tts.wav".into()) {
+                            Ok(_) => println!("File renamed successfully!"),
+                            Err(err) => {
+                                let response = ErrorResponse {
+                                    status: 400,
+                                    error: err,
+                                };
+                                let Response_json = json!(response);
+                                return Err(serde_json::to_string(&Response_json).unwrap());
+                            }
+                        }
                     }
                 }
                 Err(e) => {

--- a/src/device/rdk/voice/send_audio.rs
+++ b/src/device/rdk/voice/send_audio.rs
@@ -14,7 +14,7 @@ use crate::dab::structs::SendAudioRequest;
 use serde_json::json;
 
 use super::voice_functions::convert_audio_to_pcms16le16256;
-use super::voice_functions::require_audio_format_conversion;
+use super::voice_functions::is_supported_audio_format;
 use super::voice_functions::sendVoiceCommand;
 use crate::device::rdk::interface::http_download;
 
@@ -43,11 +43,11 @@ pub fn process(packet: String) -> Result<String, String> {
                 let Response_json = json!(response);
                 return Err(serde_json::to_string(&Response_json).unwrap());
             }
-            let result = http_download(DabRequest.fileLocation, "/tmp/tts_download.wav".into());
+            let result = http_download(DabRequest.fileLocation, "/tmp/tts.wav".into());
             match result {
                 Ok(_) => {
                     // RDK Currently supports PCM S16LE 16K 256kbps. Convert on mismatch.
-                    if require_audio_format_conversion("/tmp/tts.wav".into()) {
+                    if is_supported_audio_format("/tmp/tts.wav".into()) {
                         convert_audio_to_pcms16le16256("/tmp/tts.wav".into());
                     }
                 }

--- a/src/device/rdk/voice/send_audio.rs
+++ b/src/device/rdk/voice/send_audio.rs
@@ -13,7 +13,7 @@ use crate::dab::structs::ErrorResponse;
 use crate::dab::structs::SendAudioRequest;
 use serde_json::json;
 
-use super::voice_functions::convert_audio_to_pcms16le16256;
+use super::voice_functions::convert_audio_to_pcms16le16mono;
 use super::voice_functions::is_supported_audio_format;
 use super::voice_functions::sendVoiceCommand;
 use crate::device::rdk::interface::http_download;
@@ -47,8 +47,9 @@ pub fn process(packet: String) -> Result<String, String> {
             match result {
                 Ok(_) => {
                     // RDK Currently supports PCM S16LE 16K 256kbps. Convert on mismatch.
-                    if is_supported_audio_format("/tmp/tts.wav".into()) {
-                        convert_audio_to_pcms16le16256("/tmp/tts.wav".into());
+                    if !is_supported_audio_format("/tmp/tts.wav".into()) {
+                        println!("Calling convert_audio_to_pcms16le16mono");
+                        convert_audio_to_pcms16le16mono("/tmp/tts.wav".into());
                     }
                 }
                 Err(e) => {

--- a/src/device/rdk/voice/send_text.rs
+++ b/src/device/rdk/voice/send_text.rs
@@ -13,7 +13,7 @@ use crate::dab::structs::ErrorResponse;
 use crate::dab::structs::SendTextRequest;
 use serde_json::json;
 
-use super::voice_functions::convert_audio_to_pcms16le16256;
+use super::voice_functions::convert_audio_to_pcms16le16mono;
 use super::voice_functions::sendVoiceCommand;
 
 #[allow(non_snake_case)]
@@ -56,7 +56,8 @@ pub fn process(packet: String) -> Result<String, String> {
         .save_to_file(&Dab_Request.requestText, "/tmp/tts.mp3")
         .expect("Failed to save to file");
 
-    if convert_audio_to_pcms16le16256("/tmp/tts.mp3".into()) {
+    if convert_audio_to_pcms16le16mono("/tmp/tts.mp3".into()) {
+        println!("convert_audio_to_pcms16le16mono success.");
         sendVoiceCommand("/tmp/tts.mp3".into())?;
         return Ok(serde_json::to_string(&json!({"status": 200})).unwrap());
     }

--- a/src/device/rdk/voice/send_text.rs
+++ b/src/device/rdk/voice/send_text.rs
@@ -56,8 +56,8 @@ pub fn process(packet: String) -> Result<String, String> {
         .save_to_file(&Dab_Request.requestText, "/tmp/tts.mp3")
         .expect("Failed to save to file");
 
-    if convert_audio_to_pcms16le16256("/tmp/tts.wav".into()) {
-        sendVoiceCommand("/tmp/tts.wav".into())?;
+    if convert_audio_to_pcms16le16256("/tmp/tts.mp3".into()) {
+        sendVoiceCommand("/tmp/tts.mp3".into())?;
         return Ok(serde_json::to_string(&json!({"status": 200})).unwrap());
     }
     Ok(

--- a/src/device/rdk/voice/send_text.rs
+++ b/src/device/rdk/voice/send_text.rs
@@ -56,9 +56,9 @@ pub fn process(packet: String) -> Result<String, String> {
         .save_to_file(&Dab_Request.requestText, "/tmp/tts.mp3")
         .expect("Failed to save to file");
 
-    if convert_audio_to_pcms16le16mono("/tmp/tts.mp3".into()) {
+    if convert_audio_to_pcms16le16mono("/tmp/tts.mp3".into(), "/tmp/tts.wav".into()) {
         println!("convert_audio_to_pcms16le16mono success.");
-        sendVoiceCommand("/tmp/tts.mp3".into())?;
+        sendVoiceCommand("/tmp/tts.wav".into())?;
         return Ok(serde_json::to_string(&json!({"status": 200})).unwrap());
     }
     Ok(

--- a/src/device/rdk/voice/voice_functions.rs
+++ b/src/device/rdk/voice/voice_functions.rs
@@ -193,7 +193,7 @@ pub fn sendVoiceCommand(audio_file_in: String) -> Result<(), String> {
 }
 
 // RDK's voice stack now supports PCM S16LE 16K upto 256kbps
-pub fn require_audio_format_conversion(audio_file_in: String) -> bool {
+pub fn is_supported_audio_format(audio_file_in: String) -> bool {
     let mut samplerate = false;
     let mut bitrate = false;
     let mut codec = false;

--- a/src/device/rdk/voice/voice_functions.rs
+++ b/src/device/rdk/voice/voice_functions.rs
@@ -255,13 +255,14 @@ pub fn is_supported_audio_format(file_path: String) -> bool {
     return status;
 }
 
-pub fn convert_audio_to_pcms16le16mono(audio_file: String) -> bool {
-    let location = "location=".to_owned() + audio_file.as_str();
+pub fn convert_audio_to_pcms16le16mono(audio_file_in: String, audio_file_out: String) -> bool {
+    let location_in = "location=".to_owned() + audio_file_in.as_str();
+    let location_out = "location=".to_owned() + audio_file_out.as_str();
 
     let mut child = Command::new("gst-launch-1.0")
         .arg("-q")
         .arg("filesrc")
-        .arg(location.clone())
+        .arg(location_in)
         .arg("!")
         .arg("decodebin")
         .arg("!")
@@ -274,7 +275,7 @@ pub fn convert_audio_to_pcms16le16mono(audio_file: String) -> bool {
         .arg("wavenc")
         .arg("!")
         .arg("filesink")
-        .arg(location.clone())
+        .arg(location_out)
         .spawn()
         .expect("Failed to execute command");
     child

--- a/src/device/rdk/voice/voice_functions.rs
+++ b/src/device/rdk/voice/voice_functions.rs
@@ -222,7 +222,7 @@ pub fn is_supported_audio_format(audio_file_in: String) -> bool {
 }
 
 pub fn convert_audio_to_pcms16le16256(audio_file: String) -> bool {
-    let location = "lcoation=".to_owned() + audio_file.as_str();
+    let location = "location=".to_owned() + audio_file.as_str();
 
     let mut child = Command::new("gst-launch-1.0")
         .arg("-q")


### PR DESCRIPTION
This change addresses the following:

- Moved audio file conversion logic into a separate function.
- Added gst-discover based check for audio file compatibility against platform supported format.
- Added format conversion on all downloaded and TTS generated audio files before giving to Thunder API.