### PR TITLE
Update mute value in /system/settings/list

### DIFF
--- a/src/device/rdk/system/settings/get.rs
+++ b/src/device/rdk/system/settings/get.rs
@@ -171,7 +171,7 @@ fn get_rdk_audio_volume() -> Result<u32, String> {
     }
 }
 
-pub fn get_rdk_mute() -> Result<bool, String> {
+fn get_rdk_mute() -> Result<bool, String> {
     #[allow(non_snake_case)]
     #[derive(Serialize)]
     struct Param {

--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -282,7 +282,7 @@ pub fn process(_packet: String) -> Result<String, String> {
 
     ResponseOperator.lowLatencyMode = true;
 
-    ResponseOperator.mute = false;
+    ResponseOperator.mute = true;
 
     ResponseOperator.textToSpeech = get_rdk_tts()?;
 

--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -121,7 +121,6 @@ use serde_json::json;
 use std::collections::HashMap;
 
 use super::get::get_rdk_cec;
-use super::get::get_rdk_mute;
 use super::get::get_rdk_tts;
 
 fn get_rdk_resolutions() -> Result<Vec<OutputResolution>, String> {
@@ -283,7 +282,7 @@ pub fn process(_packet: String) -> Result<String, String> {
 
     ResponseOperator.lowLatencyMode = true;
 
-    ResponseOperator.mute = get_rdk_mute()?;
+    ResponseOperator.mute = false;
 
     ResponseOperator.textToSpeech = get_rdk_tts()?;
 


### PR DESCRIPTION
`/system/settings/list` doesn't report the current value of the mute switch, but the 'mute' value simply tells whether the device can be muted using `/system/settings/set` DAB function. It should probably be hardcoded to true for RDK.