### PR TITLE
Fix 'cec' field in /system/settings/list

### DIFF
--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -158,19 +158,27 @@ pub fn rdk_request<R: DeserializeOwned>(method: &str) -> Result<R, String> {
     #[derive(Serialize)]
     struct RdkNullParams {}
 
-    rdk_request_with_params(method, RdkNullParams {})
+    rdk_request_impl::<RdkNullParams,R>(method, None)
 }
 
 pub fn rdk_request_with_params<P: Serialize, R: DeserializeOwned>(
     method: &str,
     params: P,
 ) -> Result<R, String> {
+    rdk_request_impl(method, Some(params))
+}
+
+fn rdk_request_impl<P: Serialize, R: DeserializeOwned>(
+    method: &str,
+    params: Option<P>,
+) -> Result<R, String> {
     #[derive(Serialize)]
     struct RdkRequest<P> {
         jsonrpc: String,
         id: i32,
         method: String,
-        params: P,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        params: Option<P>,
     }
 
     static mut JSONRPC_ID: i32 = 1;

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -262,6 +262,25 @@ pub fn service_activate(service: String) -> Result<(), String> {
     }
 }
 
+pub fn service_is_available(service: &str) -> Result<bool, String> {
+    #[allow(dead_code)]
+    #[derive(Deserialize)]
+    struct Status {
+        autostart: bool,
+        callsign: String,
+    }
+
+    match rdk_request::<RdkResponse<Vec<Status>>> (format!("Controller.1.status@{service}").as_str()) {
+        Err(message) => {
+            if message == "ERROR_UNKNOWN_KEY" {
+                return Ok(false);
+            }
+            return Err(message);
+        }
+        Ok(_) => return Ok(true)
+    }
+}
+
 lazy_static! {
     static ref RDK_KEYMAP: HashMap<String, u16> = {
         let mut keycode_map = HashMap::new();

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -206,7 +206,7 @@ fn rdk_request_impl<P: Serialize, R: DeserializeOwned>(
 
     if val["error"] != serde_json::Value::Null {
         return Err(val["error"]["message"].as_str().unwrap().into());
-    } else if val["result"] != serde_json::Value::Null {
+    } else if !val["result"].is_null() && val["result"]["success"].is_boolean() {
         if !val["result"]["success"].as_bool().unwrap() {
             return Err(format!("{} failed", method));
         }

--- a/src/device/rdk/system/settings/get.rs
+++ b/src/device/rdk/system/settings/get.rs
@@ -210,7 +210,7 @@ pub fn get_rdk_tts() -> Result<bool, String> {
     Ok(rdkresponse.result.isenabled)
 }
 
-pub fn get_rdk_cec() -> Result<bool, String> {
+fn get_rdk_cec() -> Result<bool, String> {
     #[allow(dead_code)]
     #[derive(Deserialize)]
     struct CecGetEnabled {

--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -113,6 +113,7 @@ use crate::dab::structs::VideoInputSource;
 use crate::device::rdk::interface::rdk_request;
 use crate::device::rdk::interface::rdk_request_with_params;
 use crate::device::rdk::interface::rdk_sound_mode_to_dab;
+use crate::device::rdk::interface::service_is_available;
 use crate::device::rdk::interface::RdkResponse;
 use crate::device::rdk::system::settings::get::get_rdk_audio_port;
 use lazy_static::lazy_static;
@@ -277,7 +278,7 @@ pub fn process(_packet: String) -> Result<String, String> {
 
     ResponseOperator.memc = false;
 
-    ResponseOperator.cec = true;
+    ResponseOperator.cec = service_is_available ("org.rdk.HdmiCec_2")?;
 
     ResponseOperator.lowLatencyMode = true;
 

--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -120,7 +120,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use std::collections::HashMap;
 
-use super::get::get_rdk_cec;
 use super::get::get_rdk_tts;
 
 fn get_rdk_resolutions() -> Result<Vec<OutputResolution>, String> {
@@ -278,7 +277,7 @@ pub fn process(_packet: String) -> Result<String, String> {
 
     ResponseOperator.memc = false;
 
-    ResponseOperator.cec = get_rdk_cec()?;
+    ResponseOperator.cec = true;
 
     ResponseOperator.lowLatencyMode = true;
 


### PR DESCRIPTION
This flag signifies whether CEC functionality is supported at all by the RDK device, not its current enabled or disabled state (that's what /system/settings/get is for).

Let's infer the availability of CEC from asking Thunder's Controller plugin if it recognizes org.rdk.HdmiCec_2 service.