### PR TITLE
Align to DAB-2.0 specifications

### DIFF
--- a/src/device/rdk/applications/exit.rs
+++ b/src/device/rdk/applications/exit.rs
@@ -174,7 +174,7 @@ pub fn process(_packet: String) -> Result<String, String> {
         }
     }
 
-    // *******************************************************************
+    // ******************* wait until app state *************************
     for _idx in 1..=20 { // 2 seconds (20*100ms)
         // TODO: refactor to listen to Thunder events with websocket.
         thread::sleep(time::Duration::from_millis(100));

--- a/src/device/rdk/applications/launch_with_content.rs
+++ b/src/device/rdk/applications/launch_with_content.rs
@@ -13,10 +13,12 @@ use crate::dab::structs::ErrorResponse;
 #[allow(unused_imports)]
 use crate::dab::structs::LaunchApplicationWithContentRequest;
 use crate::dab::structs::LaunchApplicationWithContentResponse;
+use crate::device::rdk::applications::get_state::get_app_state;
 use crate::device::rdk::interface::http_post;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 use urlencoding::decode;
+use std::{thread, time};
 
 #[allow(non_snake_case)]
 #[allow(dead_code)]
@@ -281,6 +283,22 @@ pub fn process(_packet: String) -> Result<String, String> {
         }
         //****************org.rdk.RDKShell.moveToFront/setFocus******************************//
         move_to_front_set_focus(req_params.callsign.clone());
+    }
+
+    // ******************* wait until app state 8*************************
+    let mut app_state: String = "STOPPED".to_string();
+    for _idx in 1..=20 { // 5 seconds (20*250ms)
+        // TODO: refactor to listen to Thunder events with websocket.
+        thread::sleep(time::Duration::from_millis(250));
+        app_state = get_app_state(req_params.callsign.clone())?;
+        if app_state == "FOREGROUND".to_string()
+        {
+            break;
+        }
+    }
+
+    if app_state != "FOREGROUND" {
+        return Err("Check state request(5 second) timeout, app may not be visible to user.".to_string());
     }
 
     // *******************************************************************

--- a/src/device/rdk/voice/send_audio.rs
+++ b/src/device/rdk/voice/send_audio.rs
@@ -56,7 +56,7 @@ pub fn process(packet: String) -> Result<String, String> {
         }
     }
 
-    sendVoiceCommand()?;
+    sendVoiceCommand("/tmp/tts.wav".into())?;
 
     Ok(serde_json::to_string(&json!({"status": 200})).unwrap())
 }

--- a/src/device/rdk/voice/send_text.rs
+++ b/src/device/rdk/voice/send_text.rs
@@ -92,7 +92,7 @@ pub fn process(packet: String) -> Result<String, String> {
 
     child.wait().expect("failed to wait for child process");
 
-    sendVoiceCommand()?;
+    sendVoiceCommand("/tmp/tts.wav".into())?;
 
     Ok(serde_json::to_string(&json!({"status": 200})).unwrap())
 }

--- a/src/device/rdk/voice/send_text.rs
+++ b/src/device/rdk/voice/send_text.rs
@@ -38,6 +38,20 @@ pub fn process(packet: String) -> Result<String, String> {
 
     let Dab_Request: SendTextRequest = IncomingMessage.unwrap();
 
+    if Dab_Request.voiceSystem.is_empty() {
+        let response = ErrorResponse {
+            status: 400,
+            error: "Missing 'voiceSystem' parameter".to_string(),
+        };
+        let Response_json = json!(response);
+        return Err(serde_json::to_string(&Response_json).unwrap());
+    }
+
+    // TODO: Add other RDK specific voice protocol support confirmation.
+    if Dab_Request.voiceSystem.to_string() != "AmazonAlexa" {
+        return Err("Unsupported 'voiceSystem'.".to_string());
+    }
+
     if Dab_Request.requestText.is_empty() {
         let response = ErrorResponse {
             status: 400,


### PR DESCRIPTION
This change includes the following:

1. Added poll for app state before sending response to the launch requests which is the requirement of DAB-2.0 spec. It will wait for 5 seconds to get the app state; else will return error.
2. As per DAB-2.0 https://github.com/device-automation-bus/dab-specification-2.0/blob/main/DAB.md#request-parameters-9, voiceSystem must be enabled which is odd. If the system is already enabled; then there is no need to enable again unless the requested voiceSystem is not the enabled one. Added a check to get enabled status before calling enable function. (Enabling a voice system may require time to reconfigure or switch the voice system endpoint which would take setup time.)
3. As per DAB-2.0 https://github.com/device-automation-bus/dab-specification-2.0/blob/main/DAB.md#request-parameters-10 the 'voiceSystem' is not an optional parameter; added check to return error if payload does not contain the same.