### PR TITLE
system/settings: RDK doesn't support low latency setting

### DIFF
--- a/src/device/rdk/system/settings/get.rs
+++ b/src/device/rdk/system/settings/get.rs
@@ -295,7 +295,7 @@ pub fn process(_packet: String) -> Result<String, String> {
     response.hdrOutputMode = get_rdk_hdr_current_setting()?;
     response.audioOutputMode = get_rdk_audio_output_mode()?;
     response.audioOutputSource = get_rdk_connected_audio_source()?;
-    response.lowLatencyMode = true;
+    response.lowLatencyMode = false;
     response.textToSpeech = get_rdk_tts()?;
 
     let mut response_json = json!(response);

--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -280,7 +280,7 @@ pub fn process(_packet: String) -> Result<String, String> {
 
     ResponseOperator.cec = service_is_available ("org.rdk.HdmiCec_2")?;
 
-    ResponseOperator.lowLatencyMode = true;
+    ResponseOperator.lowLatencyMode = false;
 
     ResponseOperator.mute = true;
 

--- a/src/device/rdk/system/settings/set.rs
+++ b/src/device/rdk/system/settings/set.rs
@@ -271,7 +271,7 @@ pub fn process(_packet: String) -> Result<String, String> {
                 set_rdk_hdr_mode(serde_json::from_value::<HdrOutputMode>(value.take()).unwrap())?
             }
             "textToSpeech" => set_rdk_text_to_speech(value.take().as_bool().unwrap())?,
-            "pictureMode" | "videoInputSource" | _ => {
+            "pictureMode" | "videoInputSource" | "lowLatencyMode" | _ => {
                 return Err(format!("Setting '{}' is not supported", key))
             }
         }


### PR DESCRIPTION
Arun confirmed RDK has no APIs to control low latency on STBs. There's RDKDEV-934 requesting the missing APIs be added; until that ticket is implemented, let's return false when lowLatencyMode is listed or read.