### PR TITLE
Fix system/settings/set

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ clap = { version = "3.2", features = ["derive"] }
 paho-mqtt = { version = "0.12", default-features = false, features = ["vendored-ssl"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_with = "3.6.0"
 tungstenite = "0.20"
 bytes = "1.3.0"
 surf = { version = "2.3.2", default-features = false, features = ["h1-client-rustls"] }

--- a/src/dab/structs.rs
+++ b/src/dab/structs.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_with::skip_serializing_none;
 use std::collections::HashMap;
 pub type SharedMap = HashMap<String, RequestTypes>;
 
@@ -383,36 +384,23 @@ pub struct GetSystemSettingsResponse {
 }
 
 #[allow(non_snake_case)]
+#[skip_serializing_none]
 #[derive(Default, Serialize, Deserialize)]
 pub struct SetSystemSettingsRequest {
-    #[serde(default)]
-    pub language: String,
-    #[serde(default)]
-    pub outputResolution: OutputResolution,
-    #[serde(default)]
-    pub memc: bool,
-    #[serde(default)]
-    pub cec: bool,
-    #[serde(default)]
-    pub lowLatencyMode: bool,
-    #[serde(default)]
-    pub matchContentFrameRate: MatchContentFrameRate,
-    #[serde(default)]
-    pub hdrOutputMode: HdrOutputMode,
-    #[serde(default)]
-    pub pictureMode: PictureMode,
-    #[serde(default)]
-    pub audioOutputMode: AudioOutputMode,
-    #[serde(default)]
-    pub audioOutputSource: AudioOutputSource,
-    #[serde(default)]
-    pub videoInputSource: VideoInputSource,
-    #[serde(default)]
-    pub audioVolume: u32,
-    #[serde(default)]
-    pub mute: bool,
-    #[serde(default)]
-    pub textToSpeech: bool,
+    pub language: Option<String>,
+    pub outputResolution: Option<OutputResolution>,
+    pub memc: Option<bool>,
+    pub cec: Option<bool>,
+    pub lowLatencyMode: Option<bool>,
+    pub matchContentFrameRate: Option<MatchContentFrameRate>,
+    pub hdrOutputMode: Option<HdrOutputMode>,
+    pub pictureMode: Option<PictureMode>,
+    pub audioOutputMode: Option<AudioOutputMode>,
+    pub audioOutputSource: Option<AudioOutputSource>,
+    pub videoInputSource: Option<VideoInputSource>,
+    pub audioVolume: Option<u32>,
+    pub mute: Option<bool>,
+    pub textToSpeech: Option<bool>,
 }
 
 #[allow(non_snake_case)]


### PR DESCRIPTION
Because dab_adapter::device::rdk::system::settings::set::process() now accepts SetSystemSettingsRequest structure, it will not only set the requested setting(s), but will also attempt to set ALL other settings to their default values.

Modify SetSystemSettingsRequest definition so that:
* its members are not initialized to their default values
* all members are optional
* members with None value are skipped during serialization