### PR TITLE
Fix the issue of Setting unsupported resolution is returning success.

### DIFF
--- a/src/device/rdk/system/settings/set.rs
+++ b/src/device/rdk/system/settings/set.rs
@@ -56,14 +56,14 @@ fn set_rdk_resolution(resolution: &OutputResolution) -> Result<(), DabError> {
         videoDisplay: String,
         resolution: String,
         persist: bool,
-        ignoreEdid: bool,
+        // ignoreEdid: bool, Optional parameter; expected to fail the set call if resolution is not supported by the sink.
     }
 
     let req_params = Param {
         videoDisplay: get_rdk_connected_video_displays()?,
         resolution: convert_resolution_to_string(resolution)?,
         persist: true,
-        ignoreEdid: true,
+        // ignoreEdid: false, Optional parameter; expected to fail the set call if resolution is not supported by the sink.
     };
 
     let _rdkresponse: RdkResponseSimple =


### PR DESCRIPTION
If the sink/display is not supporting a set of resolution; API should return failure as it may not change the output as expected.
Here; the connected sink only supports the following:
```
{"supportedResolutions":["480p","720p60","1080i60","1080p24","1080p60"],"success":true}
```
**Compliance Suite Logs:**
```
d35@d35:~/Desktop/dab-works/dab-compliance-suite$ dabSingleTest SystemSettingsSetOutputresolution // Try setting 4K60

testing system/settings/set   {"outputResolution": {"width": 3840, "height": 2160, "frequency": 60} } ... [ 
Error: self.dab_client.last_error_code()
Internal error ]
{
  "status": 500,
  "error": "org.rdk.DisplaySettings.setCurrentResolution failed"
}
d35@d35:~/Desktop/dab-works/dab-compliance-suite$ 
d35@d35:~/Desktop/dab-works/dab-compliance-suite$ dabSingleTest SystemSettingsSetOutputresolution  // Try setting FHD@30

testing system/settings/set   {"outputResolution": {"width": 1920, "height": 1080, "frequency": 30} } ... [ 
Error: self.dab_client.last_error_code()
Internal error ]
{
  "status": 500,
  "error": "org.rdk.DisplaySettings.setCurrentResolution failed"
}
d35@d35:~/Desktop/dab-works/dab-compliance-suite$ 
d35@d35:~/Desktop/dab-works/dab-compliance-suite$ dabSingleTest SystemSettingsSetOutputresolution // Try setting FHD@60

testing system/settings/set   {"outputResolution": {"width": 1920, "height": 1080, "frequency": 60} } ... 
system/settings/set Latency, Expected: 3000 ms, Actual: 118 ms

[ PASS ]
{
  "status": 200
}
d35@d35:~/Desktop/dab-works/dab-compliance-suite$ 
d35@d35:~/Desktop/dab-works/dab-compliance-suite$ dabSingleTest SystemSettingsGetConformance

testing system/settings/get   {} ... 
system/settings/get Latency, Expected: 200 ms, Actual: 1315 ms

system/settings/get took more time than expected.

[ FAILED ]
{
  "audioOutputMode": "Auto",
  "audioOutputSource": "HDMI",
  "audioVolume": 0,
  "cec": true,
  "hdrOutputMode": "DisableHdr",
  "language": "en-US",
  "lowLatencyMode": false,
  "matchContentFrameRate": "EnabledAlways",
  "memc": false,
  "mute": false,
  "outputResolution": {
    "frequency": 60.0,
    "height": 1080,
    "width": 1920
  },
  "pictureMode": "Standard",
  "status": 200,
  "textToSpeech": true,
  "videoInputSource": "Home"
}
d35@d35:~/Desktop/dab-works/dab-compliance-suite$
```
**MQTT Logs:**
```
d35@d35:~/Desktop/dab-works/dab-adapter-rs$ ./target/debug/dab-adapter -b 10.0.0.74 -d 10.0.0.74
DAB<->RDK Adapter [90612236023bd162df1f06541648a8b6dcc53b67]
DAB Device ID: 02AD3201A856
Ready to process DAB requests

processing: system/settings/set
Publishing response: dab/_response/system/settings/set "{\"status\":500,\"error\":\"org.rdk.DisplaySettings.setCurrentResolution failed\"}"
processing: system/settings/set
Publishing response: dab/_response/system/settings/set "{\"status\":500,\"error\":\"org.rdk.DisplaySettings.setCurrentResolution failed\"}"
processing: system/settings/set
Publishing response: dab/_response/system/settings/set "{\"status\":200}"

processing: system/settings/get
Publishing response: dab/_response/system/settings/get "{\"audioOutputMode\":\"Auto\",\"audioOutputSource\":\"HDMI\",\"audioVolume\":0,\"cec\":true,\"hdrOutputMode\":\"DisableHdr\",\"language\":\"en-US\",\"lowLatencyMode\":false,\"matchContentFrameRate\":\"EnabledAlways\",\"memc\":false,\"mute\":false,\"outputResolution\":{\"frequency\":60.0,\"height\":1080,\"width\":1920},\"pictureMode\":\"Standard\",\"status\":200,\"textToSpeech\":true,\"videoInputSource\":\"Home\"}"

```