### PR TITLE
Update DeviceTelemetry logic

### DIFF
--- a/src/dab/mqtt_client.rs
+++ b/src/dab/mqtt_client.rs
@@ -96,8 +96,13 @@ impl MqttClient {
                 let function_topic = std::string::String::from(packet.topic());
                 let v: Vec<&str> = function_topic.split('/').collect();
                 let operator = v.get(2).unwrap_or(&"");
+                // Ignore 'messages', 'device-telemetry/metrics', and 'app-telemetry/metrics/#' since this is a DAB adapter for device.
                 if operator == &"messages" {
                     return Err(None);
+                } else if operator == &"device-telemetry" || operator == &"app-telemetry" {
+                    if v.get(3).unwrap_or(&"") == &"metrics" {
+                        return Err(None);
+                    }
                 }
 
                 let payload_str = packet.payload_str();

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -509,7 +509,24 @@ pub fn rdk_sound_mode_to_dab(mode: &String) -> Option<AudioOutputMode> {
 // Telemetry operations
 
 pub fn get_device_memory() -> Result<u32, DabError> {
-    Ok(0)
+    // Both properties are in bytes; convert to KB for DAB.
+    let free_ram_bytes = get_thunder_property("DeviceInfo.systeminfo", "freeram")?;
+    let free_ram_bytes = free_ram_bytes.parse::<u32>()
+        .map_err(|_| DabError::Err500("Failed to parse free RAM".to_string()))? / 1024;
+
+    let total_ram_bytes = get_thunder_property("DeviceInfo.systeminfo", "totalram")?;
+    let total_ram_bytes = total_ram_bytes.parse::<u32>()
+        .map_err(|_| DabError::Err500("Failed to parse total RAM".to_string()))? / 1024;
+
+    Ok(total_ram_bytes - free_ram_bytes)
+}
+
+pub fn get_device_cpu() -> Result<u32, DabError> {
+    let cpu_usage = get_thunder_property("DeviceInfo.systeminfo", "cpuload")?;
+    let cpu_usage = cpu_usage.parse::<u32>()
+        .map_err(|_| DabError::Err500("Failed to parse CPU usage".to_string()))?;
+
+    Ok(cpu_usage)
 }
 
 // Read platform override JSON configs from file

--- a/src/device/rdk/operations/list.rs
+++ b/src/device/rdk/operations/list.rs
@@ -58,6 +58,9 @@ pub fn process(_dab_request: OperationsListRequest) -> Result<String, DabError> 
     //     .push("device-telemetry/stop".to_string());
     // ResponseOperator
     //     .operations
+    //     .push("device-telemetry/metrics".to_string());
+    // ResponseOperator
+    //     .operations
     //     .push("app-telemetry/start".to_string());
     // ResponseOperator
     //     .operations


### PR DESCRIPTION
**Description:**
Update DeviceTelemetry logic to add both memory and cpu statistics.
Since its marked as an optional one; hide from operations/list.

**Test Details:**
Compliance Suite
```
testing device-telemetry/start   {"duration": 1000} ... 
device-telemetry/start Latency, Expected: 200 ms, Actual: 41 ms

[ PASS ]
{
  "duration": 1000,
  "status": 200
}

testing device-telemetry/stop   {} ... 
device-telemetry/stop Latency, Expected: 200 ms, Actual: 1521 ms

device-telemetry/stop took more time than expected.

[ FAILED ]
{
  "status": 200
}
```
MQTTListener:
```
d35@d35:~/Desktop/dab-compliance-suite$ mosquitto_sub -h 10.0.0.88 -v -t '#' | ts '[%Y%b%d %H:%M:%.S]'

[2024Apr01 20:45:27.049194] dab/02AD3201C835/device-telemetry/start {"duration": 1000}
[2024Apr01 20:45:27.060563] dab/_response/dab/02AD3201C835/device-telemetry/start {"duration":1000,"status":200}
[2024Apr01 20:45:27.157051] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018727,"metric":"memory","value":1377504}
[2024Apr01 20:45:27.166723] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018727,"metric":"cpu","value":21}
[2024Apr01 20:45:28.457443] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018728,"metric":"memory","value":1377816}
[2024Apr01 20:45:28.473605] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018728,"metric":"cpu","value":17}
[2024Apr01 20:45:29.537011] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018729,"metric":"memory","value":1377684}
[2024Apr01 20:45:29.599026] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018729,"metric":"cpu","value":21}
[2024Apr01 20:45:30.662598] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018730,"metric":"memory","value":1377812}
[2024Apr01 20:45:30.820140] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018730,"metric":"cpu","value":18}
[2024Apr01 20:45:31.803314] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018731,"metric":"memory","value":1377936}
[2024Apr01 20:45:31.812637] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018731,"metric":"cpu","value":26}
[2024Apr01 20:45:32.933374] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018732,"metric":"memory","value":1378264}
[2024Apr01 20:45:32.944023] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018732,"metric":"cpu","value":19}
[2024Apr01 20:45:34.034309] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018734,"metric":"memory","value":1378404}
[2024Apr01 20:45:34.064888] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018734,"metric":"cpu","value":24}
[2024Apr01 20:45:35.130512] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018735,"metric":"memory","value":1378720}
[2024Apr01 20:45:35.201125] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018735,"metric":"cpu","value":18}
[2024Apr01 20:45:36.363131] dab/02AD3201C835/device-telemetry/stop {}
[2024Apr01 20:45:36.373003] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018736,"metric":"memory","value":1373504}
[2024Apr01 20:45:36.382905] dab/02AD3201C835/device-telemetry/metrics {"timestamp":1712018736,"metric":"cpu","value":19}
[2024Apr01 20:45:37.846922] dab/_response/dab/02AD3201C835/device-telemetry/stop {"status":200}


```
dab-adapter logs:
```
d35@d35:~/Desktop/dab-works/dab-adapter-rs$ ./target/debug/dab-adapter -b 10.0.0.88 -d 10.0.0.88
DAB<->RDK Adapter ("0.6.0" - "8951f9a")
DAB Device ID: 02AD3201C835
Ready to process DAB requests
Publishing response: dab/_response/device-telemetry/start "{\"duration\":1000,\"status\":200}"
Publishing response: dab/_response/device-telemetry/stop "{\"status\":200}"

```