### PR TITLE
Fix launching Netflix from suspended state

### DIFF
--- a/src/device/rdk/applications/launch.rs
+++ b/src/device/rdk/applications/launch.rs
@@ -131,7 +131,7 @@ pub fn process(_dab_request: LaunchApplicationRequest) -> Result<String, DabErro
             }
         };
         send_rdkshell_launch_request(req_params)?;
-    } else {
+    } else if !is_suspended {
         // App is already created.
         if is_cobalt {
             // Cobalt plugin specific.


### PR DESCRIPTION
Hello,

Currently it's not possible to resume (launch) any app from suspended (BACKGROUND) state. Any attempt produces an error:
Internal error
> { 
> "status": 500,
> "error": "Require App specific deeplinking implementation."
> }
> 
which comes from lines 161-166:
```
        } else {
            // Other App specific deeplinking.
            return Err(DabError::Err500(
                "Require App specific deeplinking implementation.".to_string(),
            ));
        }
```
Thanks!