### PR TITLE
Refactor app state logic (launch and exit)

### DIFF
--- a/src/dab.rs
+++ b/src/dab.rs
@@ -303,7 +303,7 @@ pub fn run(mqtt_server: String, mqtt_port: u16, mut function_map: SharedMap) {
                 } else {
                     payload.chars().take(255).collect::<String>()
                 };
-                println!("Publishing response: {} {:?}", response_topic.clone().replace(&substring, ""), limited_payload.as_str());
+                println!("Publishing response: {} {}\n", response_topic.clone().replace(&substring, ""), limited_payload.as_str());
             }
             Err(err) => {
                 if let Some(msg) = err {

--- a/src/device/rdk/applications/exit.rs
+++ b/src/device/rdk/applications/exit.rs
@@ -2,9 +2,8 @@ use crate::dab::structs::DabError;
 use crate::dab::structs::ExitApplicationRequest;
 use crate::dab::structs::ExitApplicationResponse;
 use crate::device::rdk::applications::get_state::get_dab_app_state;
-use crate::device::rdk::interface::http_post;
+use crate::device::rdk::applications::launch::{rdkshell_suspend, rdkshell_destroy};
 use crate::device::rdk::interface::get_lifecycle_timeout;
-use serde::{Deserialize, Serialize};
 use std::{thread, time};
 
 #[allow(non_snake_case)]
@@ -12,127 +11,67 @@ use std::{thread, time};
 #[allow(unused_mut)]
 pub fn process(_dab_request: ExitApplicationRequest) -> Result<String, DabError> {
     let mut ResponseOperator = ExitApplicationResponse::default();
-    // *** Fill in the fields of the struct ExitApplicationResponse here ***
     if _dab_request.appId.is_empty() {
         return Err(DabError::Err400(
             "request missing 'appId' parameter".to_string(),
         ));
     }
 
-    let mut is_background = false;
-    if _dab_request.background.is_some() && _dab_request.background.unwrap() {
-        is_background = true;
-    }
+    // background default is false
+    let to_background = _dab_request.background.unwrap_or(false);
 
-    // RDK Request Common Structs
-    #[derive(Serialize, Clone)]
-    struct RequestParams {
-        callsign: String,
-    }
-
-    #[derive(Serialize)]
-    struct RdkRequest {
-        jsonrpc: String,
-        id: i32,
-        method: String,
-        params: RequestParams,
-    }
-
-    let req_params = RequestParams {
-        callsign: _dab_request.appId.clone(),
-    };
-    // ****************** org.rdk.RDKShell.getState ********************
-    #[derive(Serialize)]
-    struct RdkRequestGetState {
-        jsonrpc: String,
-        id: i32,
-        method: String,
-    }
-
-    let request = RdkRequestGetState {
-        jsonrpc: "2.0".into(),
-        id: 3,
-        method: "org.rdk.RDKShell.getState".into(),
-    };
-
-    #[derive(Deserialize)]
-    struct Runtimes {
-        callsign: String,
-        state: String,
-        uri: String,
-        lastExitReason: i32,
-    }
-
-    #[derive(Deserialize)]
-    struct GetStateResult {
-        state: Vec<Runtimes>,
-        success: bool,
-    }
-
-    #[derive(Deserialize)]
-    struct RdkResponseGetState {
-        jsonrpc: String,
-        id: i32,
-        result: GetStateResult,
-    }
-
-    let json_string = serde_json::to_string(&request).unwrap();
-    let response = http_post(json_string)?;
-
-    let rdkresponse: RdkResponseGetState = serde_json::from_str(&response).unwrap();
-    let mut app_created = false;
-    for r in rdkresponse.result.state.iter() {
-        let app = r.callsign.clone();
-        if app == _dab_request.appId {
-            app_created = true;
-        }
-    }
-
-    if app_created {
-        if is_background {
-            // ****************** org.rdk.RDKShell.suspend ********************
-            let request = RdkRequest {
-                jsonrpc: "2.0".into(),
-                id: 3,
-                method: "org.rdk.RDKShell.suspend".into(),
-                params: req_params.clone(),
-            };
-
-            let json_string = serde_json::to_string(&request).unwrap();
-            http_post(json_string)?;
-        } else {
-            // ****************** org.rdk.RDKShell.destroy ********************
-            let request = RdkRequest {
-                jsonrpc: "2.0".into(),
-                id: 3,
-                method: "org.rdk.RDKShell.destroy".into(),
-                params: req_params.clone(),
-            };
-
-            let json_string = serde_json::to_string(&request).unwrap();
-            http_post(json_string)?;
+    let mut was_stopped = false;
+    let app_state = get_dab_app_state(_dab_request.appId.clone())?;
+    match app_state.as_str() {
+        "BACKGROUND" | "FOREGROUND" => {
+            if to_background {
+                rdkshell_suspend(_dab_request.appId.clone())?;
+            } else {
+                rdkshell_destroy(_dab_request.appId.clone())?;
+            }
+        },
+        "STOPPED" => {
+            was_stopped = true;
+        },
+        _ => {
+            println!("Should not reach here in any condition. Invalid {} App state: {}",
+                _dab_request.appId, app_state.as_str());
         }
     }
 
     // *******************************************************************
-    for _idx in 1..=20 {
-        // 2 seconds (20*100ms)
+    for _idx in 1..=8 {
+        // 2 seconds (8*250ms)
         // TODO: refactor to listen to Thunder events with websocket.
-        thread::sleep(time::Duration::from_millis(100));
+        thread::sleep(time::Duration::from_millis(250));
+
+        if was_stopped && to_background {
+            println!("{} was already STOPPED before putting to BACKGROUND; Exiting loop.", _dab_request.appId);
+            wait_till_app_exit_timeout(&_dab_request.appId, "exit_to_background_timeout_ms");
+            break;
+        }
+
         ResponseOperator.state = get_dab_app_state(_dab_request.appId.clone())?;
-        if (is_background && (ResponseOperator.state == "BACKGROUND".to_string()))
-            || (!is_background && (ResponseOperator.state == "STOPPED".to_string()))
-        {
-            let timeout_type = if is_background {
+
+        if is_state_match(&ResponseOperator.state, to_background) {
+            let timeout_type = if to_background {
                 "exit_to_background_timeout_ms"
             } else {
                 "exit_to_destroy_timeout_ms"
             };
             
-            let sleep_time = get_lifecycle_timeout(&_dab_request.appId.to_lowercase(), timeout_type).unwrap_or(2500);
-            std::thread::sleep(time::Duration::from_millis(sleep_time));
+            wait_till_app_exit_timeout(&_dab_request.appId, timeout_type);
             break;
         }
     }
     Ok(serde_json::to_string(&ResponseOperator).unwrap())
+}
+
+fn wait_till_app_exit_timeout(app_id: &str, timeout_type: &str) {
+    let sleep_time = get_lifecycle_timeout(&app_id.to_lowercase(), timeout_type).unwrap_or(2500);
+    std::thread::sleep(time::Duration::from_millis(sleep_time));
+}
+
+fn is_state_match(state: &str, to_background: bool) -> bool {
+    (to_background && (state == "BACKGROUND")) || (!to_background && (state == "STOPPED"))
 }

--- a/src/device/rdk/applications/exit.rs
+++ b/src/device/rdk/applications/exit.rs
@@ -1,7 +1,7 @@
 use crate::dab::structs::DabError;
 use crate::dab::structs::ExitApplicationRequest;
 use crate::dab::structs::ExitApplicationResponse;
-use crate::device::rdk::applications::get_state::get_app_state;
+use crate::device::rdk::applications::get_state::get_dab_app_state;
 use crate::device::rdk::interface::http_post;
 use crate::device::rdk::interface::get_lifecycle_timeout;
 use serde::{Deserialize, Serialize};
@@ -119,7 +119,7 @@ pub fn process(_dab_request: ExitApplicationRequest) -> Result<String, DabError>
         // 2 seconds (20*100ms)
         // TODO: refactor to listen to Thunder events with websocket.
         thread::sleep(time::Duration::from_millis(100));
-        ResponseOperator.state = get_app_state(_dab_request.appId.clone())?;
+        ResponseOperator.state = get_dab_app_state(_dab_request.appId.clone())?;
         if (is_background && (ResponseOperator.state == "BACKGROUND".to_string()))
             || (!is_background && (ResponseOperator.state == "STOPPED".to_string()))
         {

--- a/src/device/rdk/applications/get_state.rs
+++ b/src/device/rdk/applications/get_state.rs
@@ -58,13 +58,21 @@ pub fn get_dab_app_state(callsign: String) -> Result<String, DabError> {
                 "suspended" => return Ok(DABAppState::Background.as_str().to_string()),
                 "activated" | "resumed" => {
                     // Launch request mandates that application should be focused and visible.
-                    // Check visibility of the application and return the state as foreground if visible else background
                     let visibility = get_visibility(callsign)?;
-                    let app_state = if visibility { DABAppState::Foreground } else { DABAppState::Background };
+                    let app_state = if visibility {
+                        DABAppState::Foreground
+                    } else {
+                        DABAppState::Background
+                    };
                     return Ok(app_state.as_str().to_string());
                 },
                 _ => {
-                    println!("Implement verification of: {:?} App state: {}", callsign.clone(), item.state.as_str());
+                    println!("Implement verification of: {} App state: {}",
+                        callsign.clone(), item.state.as_str());
+                    return Err(DabError::Err500(
+                        format!("RDKShell.getState; {} is in invalid state {}.",
+                            callsign.clone(), item.state.as_str()).to_string(),
+                    ));
                 }
             }
         }

--- a/src/device/rdk/applications/launch.rs
+++ b/src/device/rdk/applications/launch.rs
@@ -88,16 +88,6 @@ pub fn process(_dab_request: LaunchApplicationRequest) -> Result<String, DabErro
         },
         "BACKGROUND" | "FOREGROUND" => {
             app_created = false;
-            // App is suspended; resume/relaunch app then deeplink.
-            let request = RdkRequest {
-                jsonrpc: "2.0".into(),
-                id: 3,
-                method: "org.rdk.RDKShell.launch".into(),
-                params: &launch_req_params,
-            };
-    
-            let json_string = serde_json::to_string(&request).unwrap();
-            http_post(json_string)?;
 
             //// FIXME: If parameters(?) are App startup specific, it may not take effect when resuming.
             // if param_list.len() > 0 {
@@ -125,6 +115,18 @@ pub fn process(_dab_request: LaunchApplicationRequest) -> Result<String, DabErro
                     "Require App specific deeplinking implementation.".to_string(),
                 ));
             }
+
+            // App is suspended; resume/relaunch app.
+            let request = RdkRequest {
+                jsonrpc: "2.0".into(),
+                id: 3,
+                method: "org.rdk.RDKShell.launch".into(),
+                params: &launch_req_params,
+            };
+
+            let json_string = serde_json::to_string(&request).unwrap();
+            http_post(json_string)?;
+
         },
         _ => {
             println!("Should not reach here in any condition. Invalid {} App state: {}",

--- a/src/device/rdk/applications/launch.rs
+++ b/src/device/rdk/applications/launch.rs
@@ -1,6 +1,5 @@
 use crate::dab::structs::DabError;
 use crate::dab::structs::LaunchApplicationRequest;
-use crate::dab::structs::LaunchApplicationResponse;
 use crate::device::rdk::applications::get_state::get_dab_app_state;
 use crate::device::rdk::interface::http_post;
 use crate::device::rdk::interface::get_lifecycle_timeout;
@@ -10,41 +9,41 @@ use serde_json::json;
 use std::{thread, time};
 use urlencoding::decode;
 
+#[derive(Serialize, Clone)]
+pub struct RDKShellRequestParams {
+    pub callsign: String,
+}
+
+#[derive(Serialize)]
+pub struct RdkRequest<T> {
+    pub jsonrpc: String,
+    pub id: i32,
+    pub method: String,
+    pub params: T,
+}
+
 #[allow(non_snake_case)]
 #[allow(dead_code)]
 #[allow(unused_mut)]
 pub fn process(_dab_request: LaunchApplicationRequest) -> Result<String, DabError> {
-    let mut ResponseOperator = LaunchApplicationResponse::default();
-    // *** Fill in the fields of the struct LaunchApplicationResponse here ***
     if _dab_request.appId.is_empty() {
         return Err(DabError::Err400(
             "request missing 'appId' parameter".to_string(),
         ));
     }
 
-    // RDK Request Common Structs
-    #[derive(Serialize, Clone)]
-    struct RequestParams {
-        callsign: String,
-    }
-
-    #[derive(Serialize)]
-    struct RdkRequest {
-        jsonrpc: String,
-        id: i32,
-        method: String,
-        params: RequestParams,
-    }
-
-    let req_params = RequestParams {
+    let launch_req_params = RDKShellRequestParams {
         callsign: _dab_request.appId.clone(),
     };
-    let mut app_created = false;
+    
     let is_cobalt = _dab_request.appId == "Cobalt"
         || _dab_request.appId == "Youtube"
         || _dab_request.appId == "YouTube";
+    
     let is_netflix = _dab_request.appId == "Netflix";
+    
     let mut param_list = vec![];
+
     if let Some(mut parameters) = _dab_request.parameters.clone() {
         if parameters.len() > 0 {
             if is_cobalt {
@@ -57,17 +56,16 @@ pub fn process(_dab_request: LaunchApplicationRequest) -> Result<String, DabErro
         }
     }
 
-    let app_state = get_dab_app_state(req_params.callsign.clone())?;
-    println!("LAUNCHER App state: {}", app_state.as_str());
+    let mut app_created = true;
+    let app_state = get_dab_app_state(_dab_request.appId.clone())?;
     match app_state.as_str() {
         "STOPPED" => {
-            app_created = true;
             // Cold launch of app.
             let req_params = if is_cobalt {
                 let url = format!("https://www.youtube.com/tv?{}", param_list.join("&"));
                 let config = json!({"url": url});
                 RDKShellParams {
-                    callsign: _dab_request.appId,
+                    callsign: _dab_request.appId.clone(),
                     r#type: "Cobalt".into(),
                     configuration: Some(config.to_string()),
                 }
@@ -75,106 +73,73 @@ pub fn process(_dab_request: LaunchApplicationRequest) -> Result<String, DabErro
                 let querystring = format!("{}", param_list.join("&"));
                 let config = json!({"querystring": querystring});
                 RDKShellParams {
-                    callsign: _dab_request.appId,
+                    callsign: _dab_request.appId.clone(),
                     r#type: "Netflix".into(),
                     configuration: Some(config.to_string()),
                 }
             } else {
                 RDKShellParams {
-                    callsign: _dab_request.appId,
+                    callsign: _dab_request.appId.clone(),
                     r#type: "LightningApp".into(),
                     configuration: None,
                 }
             };
             send_rdkshell_launch_request(req_params)?;
         },
-        "BACKGROUND" => {
+        "BACKGROUND" | "FOREGROUND" => {
+            app_created = false;
             // App is suspended; resume/relaunch app then deeplink.
             let request = RdkRequest {
                 jsonrpc: "2.0".into(),
                 id: 3,
                 method: "org.rdk.RDKShell.launch".into(),
-                params: req_params.clone(),
+                params: &launch_req_params,
             };
     
             let json_string = serde_json::to_string(&request).unwrap();
             http_post(json_string)?;
-            // Do app specific deeplinking.
-            if is_cobalt {
-                // Cobalt plugin specific.
-                #[derive(Serialize)]
-                struct Param {
-                    url: String,
-                }
-                #[derive(Serialize)]
-                struct RdkRequest {
-                    jsonrpc: String,
-                    id: i32,
-                    method: String,
-                    params: String,
-                }
-    
-                let request = RdkRequest {
-                    jsonrpc: "2.0".into(),
-                    id: 3,
-                    method: _dab_request.appId.clone() + ".1.deeplink".into(),
-                    params: format!("https://www.youtube.com/tv?{}", param_list.join("&")),
-                };
-    
-                let json_string = serde_json::to_string(&request).unwrap();
-                http_post(json_string)?;
-            } else {
-                // Other App specific deeplinking.
-                return Err(DabError::Err500(
-                    "Require App specific deeplinking implementation.".to_string(),
-                ));
-            }
-        },
-        "FOREGROUND" => {
-            // Do app specific deeplinking.
-            if is_cobalt {
-                // Cobalt plugin specific.
-                #[derive(Serialize)]
-                struct Param {
-                    url: String,
-                }
-                #[derive(Serialize)]
-                struct RdkRequest {
-                    jsonrpc: String,
-                    id: i32,
-                    method: String,
-                    params: String,
-                }
-    
-                let request = RdkRequest {
-                    jsonrpc: "2.0".into(),
-                    id: 3,
-                    method: _dab_request.appId.clone() + ".1.deeplink".into(),
-                    params: format!("https://www.youtube.com/tv?{}", param_list.join("&")),
-                };
-    
-                let json_string = serde_json::to_string(&request).unwrap();
-                http_post(json_string)?;
-            } else {
-                // Other App specific deeplinking.
-                return Err(DabError::Err500(
-                    "Require App specific deeplinking implementation.".to_string(),
-                ));
-            }
-        },
 
+            //// FIXME: If parameters(?) are App startup specific, it may not take effect when resuming.
+            // if param_list.len() > 0 {
+            //     return Err(DabError::Err500(
+            //         format!("{} runtime is being resumed; can't pass launch parameters.",
+            //             _dab_request.appId.clone()).to_string(),
+            //     ));
+            // }
+
+            // Do app specific deeplinking.
+            if is_cobalt {
+                // Cobalt plugin specific.
+                let request = RdkRequest {
+                    jsonrpc: "2.0".into(),
+                    id: 3,
+                    method: _dab_request.appId.clone() + ".1.deeplink".into(),
+                    params: format!("https://www.youtube.com/tv?{}", param_list.join("&")),
+                };
+    
+                let json_string = serde_json::to_string(&request).unwrap();
+                http_post(json_string)?;
+            } else {
+                // Other App specific deeplinking.
+                return Err(DabError::Err500(
+                    "Require App specific deeplinking implementation.".to_string(),
+                ));
+            }
+        },
         _ => {
-            println!("Should not reach here in any condition. Invalid {:?} App state: {}", req_params.callsign.clone(), app_state.as_str());
+            println!("Should not reach here in any condition. Invalid {} App state: {}",
+                _dab_request.appId.clone(), app_state.as_str());
         }
     }
-    move_to_front_set_focus(req_params.callsign.clone())?;
-    if !get_visibility(req_params.callsign.clone())? {
-        set_visibility(req_params.callsign.clone(), true)?;
+
+    move_to_front_set_focus(_dab_request.appId.clone())?;
+    if !get_visibility(_dab_request.appId.clone())? {
+        set_visibility(_dab_request.appId.clone(), true)?;
     }
 
-    wait_till_app_starts(req_params.callsign, app_created)?;
+    wait_till_app_starts(_dab_request.appId, app_created)?;
 
-    Ok(serde_json::to_string(&ResponseOperator).unwrap())
+    Ok("{}".to_string())
 }
 
 //******************************* Generic Implementation for Reuse *******************************/
@@ -187,7 +152,7 @@ pub struct RDKShellParams {
 }
 
 #[derive(Serialize)]
-pub struct RdkRequestWithParamConfig {
+pub struct RDKShellRequestWithParamConfig {
     pub jsonrpc: String,
     pub id: i32,
     pub method: String,
@@ -211,7 +176,7 @@ pub fn send_rdkshell_launch_request(params: RDKShellParams) -> Result<(), DabErr
         result: LaunchResult,
     }
 
-    let request = RdkRequestWithParamConfig {
+    let request = RDKShellRequestWithParamConfig {
         jsonrpc: "2.0".into(),
         id: 3,
         method: "org.rdk.RDKShell.launch".into(),

--- a/src/device/rdk/applications/launch.rs
+++ b/src/device/rdk/applications/launch.rs
@@ -313,6 +313,62 @@ pub fn get_visibility(client: String) -> Result<bool, DabError> {
     Ok(rdkresponse.result.visible)
 }
 
+pub fn rdkshell_suspend(callsign:String) -> Result<String, DabError> {
+    #[derive(Serialize)]
+    struct RdkRequest {
+        jsonrpc: String,
+        id: i32,
+        method: String,
+        params: RequestParams,
+    }
+
+    #[derive(Serialize)]
+    struct RequestParams {
+        callsign: String,
+    }
+
+    let request = RdkRequest {
+        jsonrpc: "2.0".into(),
+        id: 3,
+        method: "org.rdk.RDKShell.suspend".into(),
+        params: RequestParams {
+            callsign: callsign,
+        },
+    };
+
+    let json_string = serde_json::to_string(&request).unwrap();
+    http_post(json_string)?;
+    Ok("{}".to_string())
+}
+
+pub fn rdkshell_destroy(callsign:String) -> Result<String, DabError> {
+    #[derive(Serialize)]
+    struct RdkRequest {
+        jsonrpc: String,
+        id: i32,
+        method: String,
+        params: RequestParams,
+    }
+
+    #[derive(Serialize)]
+    struct RequestParams {
+        callsign: String,
+    }
+
+    let request = RdkRequest {
+        jsonrpc: "2.0".into(),
+        id: 3,
+        method: "org.rdk.RDKShell.destroy".into(),
+        params: RequestParams {
+            callsign: callsign,
+        },
+    };
+
+    let json_string = serde_json::to_string(&request).unwrap();
+    http_post(json_string)?;
+    Ok("{}".to_string())
+}
+
 pub fn wait_till_app_starts(req_params: String, app_created: bool) -> Result<(), DabError> {
     let mut app_state: String = "STOPPED".to_string();
     for _idx in 1..=20 {

--- a/src/device/rdk/applications/launch_with_content.rs
+++ b/src/device/rdk/applications/launch_with_content.rs
@@ -82,24 +82,27 @@ pub fn process(_dab_request: LaunchApplicationWithContentRequest) -> Result<Stri
         },
         "BACKGROUND" | "FOREGROUND" => {
             app_created = false;
-            // FIXME: If parameters(?) are App startup specific, it may not take effect when resuming.
-            if is_cobalt {
-                // Cobalt plugin specific.
-                let request = RdkRequest {
-                    jsonrpc: "2.0".into(),
-                    id: 3,
-                    method: _dab_request.appId.clone() + ".1.deeplink".into(),
-                    params: format!("https://www.youtube.com/tv?{}", param_list.join("&")),
-                };
-    
-                let json_string = serde_json::to_string(&request).unwrap();
-                http_post(json_string)?;
-            } else {
-                // Other App specific deeplinking.
-                return Err(DabError::Err500(
-                    format!("Missing {} specific deeplinking implementation.",
-                        _dab_request.appId.clone()).to_string(),
-                ));
+            // FIXME: If parameters(?) are App startup specific, it may not take effect when resuming "plugin" runtime.
+            // Deeplink is required only if you need to pass "content" to the app runtime.
+            if param_list.len() > 0 {
+                if is_cobalt {
+                    // Cobalt plugin specific.
+                    let request = RdkRequest {
+                        jsonrpc: "2.0".into(),
+                        id: 3,
+                        method: _dab_request.appId.clone() + ".1.deeplink".into(),
+                        params: format!("https://www.youtube.com/tv?{}", param_list.join("&")),
+                    };
+        
+                    let json_string = serde_json::to_string(&request).unwrap();
+                    http_post(json_string)?;
+                } else {
+                    // TODO: Expand to support other App specific deeplinking.
+                    return Err(DabError::Err500(
+                        format!("Missing {} specific deeplinking implementation.",
+                            _dab_request.appId.clone()).to_string(),
+                    ));
+                }
             }
             // Resume the app runtime.
             let request = RdkRequest {

--- a/src/device/rdk/applications/launch_with_content.rs
+++ b/src/device/rdk/applications/launch_with_content.rs
@@ -1,14 +1,14 @@
 use crate::dab::structs::DabError;
 use crate::dab::structs::LaunchApplicationWithContentRequest;
-use crate::dab::structs::LaunchApplicationWithContentResponse;
 use crate::device::rdk::applications::launch::move_to_front_set_focus;
-use crate::device::rdk::applications::launch::RDKShellParams;
+use crate::device::rdk::applications::launch::{RDKShellParams,RDKShellRequestParams};
+use crate::device::rdk::applications::launch::RdkRequest;
 use crate::device::rdk::applications::launch::send_rdkshell_launch_request;
+use crate::device::rdk::applications::get_state::get_dab_app_state;
 use crate::device::rdk::interface::http_post;
 use crate::hw_specific::applications::launch::get_visibility;
 use crate::hw_specific::applications::launch::set_visibility;
 use crate::hw_specific::applications::launch::wait_till_app_starts;
-use serde::{Deserialize, Serialize};
 use serde_json::json;
 use urlencoding::decode;
 
@@ -16,15 +16,13 @@ use urlencoding::decode;
 #[allow(dead_code)]
 #[allow(unused_mut)]
 pub fn process(_dab_request: LaunchApplicationWithContentRequest) -> Result<String, DabError> {
-    let mut ResponseOperator = LaunchApplicationWithContentResponse::default();
-    // *** Fill in the fields of the struct LaunchApplicationWithContentResponse here ***
-
     if _dab_request.appId.is_empty() {
         return Err(DabError::Err400(
             "request missing 'appId' parameter".to_string(),
         ));
     }
 
+    // TODO: expand this to support more apps.
     if !(_dab_request.appId == "Cobalt"
         || _dab_request.appId == "Youtube"
         || _dab_request.appId == "YouTube")
@@ -34,84 +32,22 @@ pub fn process(_dab_request: LaunchApplicationWithContentRequest) -> Result<Stri
         ));
     }
 
-    // ****** RDK Request Common Structs ********
-
-    #[derive(Serialize, Clone)]
-    struct RequestParams {
-        callsign: String,
-    }
-
-    #[derive(Serialize)]
-    struct RdkRequest {
-        jsonrpc: String,
-        id: i32,
-        method: String,
-        params: RequestParams,
-    }
-
-    let req_params = RequestParams {
+    let launch_req_params = RDKShellRequestParams {
         callsign: _dab_request.appId.clone(),
     };
 
-    // ****************** org.rdk.RDKShell.getState ********************
-    #[derive(Serialize)]
-    struct RdkRequestGetState {
-        jsonrpc: String,
-        id: i32,
-        method: String,
-    }
-
-    let request = RdkRequestGetState {
-        jsonrpc: "2.0".into(),
-        id: 3,
-        method: "org.rdk.RDKShell.getState".into(),
-    };
-
-    #[derive(Deserialize)]
-    struct Runtimes {
-        callsign: String,
-        state: String,
-        uri: String,
-        lastExitReason: i32,
-    }
-
-    #[derive(Deserialize)]
-    struct GetStateResult {
-        state: Vec<Runtimes>,
-        success: bool,
-    }
-
-    #[derive(Deserialize)]
-    struct RdkResponseGetState {
-        jsonrpc: String,
-        id: i32,
-        result: GetStateResult,
-    }
-
-    let json_string = serde_json::to_string(&request).unwrap();
-    let response = http_post(json_string)?;
-
-    let rdkresponse: RdkResponseGetState = serde_json::from_str(&response).unwrap();
-    let mut app_created = false;
-    let mut is_suspended = false;
-    for r in rdkresponse.result.state.iter() {
-        let app = r.callsign.clone();
-        if app == _dab_request.appId {
-            app_created = true;
-            is_suspended = r.state == "suspended";
-        }
-    }
     let is_cobalt = _dab_request.appId == "Cobalt"
         || _dab_request.appId == "Youtube"
         || _dab_request.appId == "YouTube";
+
     let mut param_list = vec![];
-    if is_cobalt {
-        if !(_dab_request.contentId.is_empty()) {
-            param_list.push(format!("v={}", _dab_request.contentId.clone()));
-        }
+    // TODO: How to pass contentId to other apps may be different.
+    if is_cobalt && !_dab_request.contentId.is_empty() {
+        param_list.push(format!("v={}", _dab_request.contentId));
     }
 
     if let Some(mut parameters) = _dab_request.parameters {
+        // TODO: convert received URL encoded list of parameters to matching format to app.
         if is_cobalt {
             // Decode each parameter before appending to the list
             for param in &mut parameters {
@@ -121,63 +57,73 @@ pub fn process(_dab_request: LaunchApplicationWithContentRequest) -> Result<Stri
         param_list.append(&mut parameters);
     }
 
-    if app_created {
-        if is_cobalt {
-            // ****************** Youtube.1.deeplink ********************
-            #[derive(Serialize)]
-            struct RdkRequest {
-                jsonrpc: String,
-                id: i32,
-                method: String,
-                params: String,
+    let mut app_created = true;
+    let app_state = get_dab_app_state(_dab_request.appId.clone())?;
+
+    match app_state.as_str() {
+        "STOPPED" => {
+            // Cold launch of app.
+            let req_params = if is_cobalt {
+                let url = format!("https://www.youtube.com/tv?{}", param_list.join("&"));
+                let config = json!({"url": url});
+                RDKShellParams {
+                    callsign: _dab_request.appId.clone(),
+                    r#type: "Cobalt".into(),
+                    configuration: Some(config.to_string()),
+                }
+            } else {
+                // TODO: expand this to support other apps.
+                return Err(DabError::Err500(
+                    format!("Implementation required to support {} contents.",
+                        _dab_request.appId.clone()).to_string(),
+                ));
+            };
+            send_rdkshell_launch_request(req_params)?;
+        },
+        "BACKGROUND" | "FOREGROUND" => {
+            app_created = false;
+            // FIXME: If parameters(?) are App startup specific, it may not take effect when resuming.
+            if is_cobalt {
+                // Cobalt plugin specific.
+                let request = RdkRequest {
+                    jsonrpc: "2.0".into(),
+                    id: 3,
+                    method: _dab_request.appId.clone() + ".1.deeplink".into(),
+                    params: format!("https://www.youtube.com/tv?{}", param_list.join("&")),
+                };
+    
+                let json_string = serde_json::to_string(&request).unwrap();
+                http_post(json_string)?;
+            } else {
+                // Other App specific deeplinking.
+                return Err(DabError::Err500(
+                    format!("Missing {} specific deeplinking implementation.",
+                        _dab_request.appId.clone()).to_string(),
+                ));
             }
+            // Resume the app runtime.
             let request = RdkRequest {
                 jsonrpc: "2.0".into(),
                 id: 3,
-                method: _dab_request.appId.clone() + ".1.deeplink".into(),
-                params: format!("https://www.youtube.com/tv?{}", param_list.join("&")),
+                method: "org.rdk.RDKShell.launch".into(),
+                params: &launch_req_params,
             };
+    
             let json_string = serde_json::to_string(&request).unwrap();
             http_post(json_string)?;
+        },
+        _ => {
+            println!("Should not reach here in any condition. Invalid {:?} App state: {}",
+                _dab_request.appId.clone(), app_state.as_str());
         }
-        // TODO: Add other apps here
-        if is_suspended {
-            // RDKShell.launch will resume the app if it is suspended.
-            let req_params = RDKShellParams {
-                callsign: _dab_request.appId.clone(),
-                r#type: "Cobalt".into(),
-                configuration: None,
-            };
-            send_rdkshell_launch_request(req_params)?;
-        }
-        //****************org.rdk.RDKShell.moveToFront/setFocus******************************//
-        move_to_front_set_focus(req_params.callsign.clone())?;
-        if !get_visibility(req_params.callsign.clone())? {
-            set_visibility(req_params.callsign.clone(), true)?;
-        }
-    } else {
-        // Cold launch
-        // ****************** org.rdk.RDKShell.launch ******************** //
-        let req_params = if is_cobalt {
-            let url = format!("https://www.youtube.com/tv?{}", param_list.join("&"));
-            let config = json!({"url": url});
-            RDKShellParams {
-                callsign: _dab_request.appId.clone(),
-                r#type: "Cobalt".into(),
-                configuration: Some(config.to_string()),
-            }
-        } else {
-            // Common webapp?. URL is not provided in the request; hence do not override.
-            RDKShellParams {
-                callsign: _dab_request.appId.clone(),
-                r#type: "LightningApp".into(),
-                configuration: None,
-            }
-        };
-        send_rdkshell_launch_request(req_params)?;
     }
 
-    wait_till_app_starts(req_params.callsign, app_created)?;
+    move_to_front_set_focus(_dab_request.appId.clone())?;
+    if !get_visibility(_dab_request.appId.clone())? {
+        set_visibility(_dab_request.appId.clone(), true)?;
+    }
 
-    Ok(serde_json::to_string(&ResponseOperator).unwrap())
+    wait_till_app_starts(_dab_request.appId, app_created)?;
+
+    Ok("{}".to_string())
 }

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -598,6 +598,22 @@ lazy_static! {
         });
 
         match read_platform_config_json("/opt/dab_platform_app_lifecycle.json") {
+            /* File Format Reference:
+                {
+                    "youtube": {
+                        "cold_launch_timeout_ms": 6000,
+                        "resume_launch_timeout_ms": 3000,
+                        "exit_to_destroy_timeout_ms": 2500,
+                        "exit_to_background_timeout_ms": 2000
+                    },
+                    "netflix": {
+                        "cold_launch_timeout_ms": 6000,
+                        "resume_launch_timeout_ms": 3000,
+                        "exit_to_destroy_timeout_ms": 2500,
+                        "exit_to_background_timeout_ms": 2000
+                    }
+                }
+            */
             Ok(json_file) => {
                 match serde_json::from_str::<HashMap<String, HashMap<String, u64>>>(&json_file) {
                     Ok(app_lifecycle_config) => {


### PR DESCRIPTION
This change tries to address the issues mentioned in https://github.com/device-automation-bus/dab-adapter-rs/issues/55

> 1. There is a function get_app_state in get_state.rs file but there are also at least three copies of full implementations to get app state in exit.rs, luanch.rs and launch_with_content.rs with multiple strings manipulations beyond that. The suggestion is to have just one function for that purpose to get app state which returns enum value.

Changed the logic to map to DAB app state and used that to derive the required functionalities.

> 2. Boolean variables app_created and is_suspended in those files are just emulation of tri-state app status we're getting from RDKShell. To get the correct state of the app the code in general should check both variables at the same time. Missing that creates problems like https://github.com/device-automation-bus/dab-adapter-rs/pull/54. Adding more apps will complicate logic even more.

Current DAB app state(BACKGROUND/FOREGROUND/STOPPED) and requested DAB App state(FOREGROUND & EXIT[BACKGROUND/STOPPED]) will not match perfectly with Thunder Plugin states(https://github.com/rdkcentral/Thunder/blob/master/Source/WPEFramework/doc/ControllerPlugin.md#statechange-event). Added most apt logic to map them(https://github.com/device-automation-bus/dab-adapter-rs/compare/main...arun-madhavan-013:dab-adapter-rs:refactor-app-state-logic?expand=1#diff-96f97360a68b1faed52609b4a342f5c41d88d79e93546c12ac17a4fac2dfc694R57).

> Ideally DAB states looks better as ( STOPPED, BACKGROUND, FOREGROUND), but FOREGROUND in DAB means resumed, visible, and in focus. RDKShell returning app state "resumed" doesn't assume that app is visible or in focus. Just that the app is running. Visibility and Focus are controlled and retrieved separately. So the code in **get_state.rs** is actually incorrect for returning something like FOREGROUND state. It probably works fine with just one app tests (like "YouTube") but with multiple apps it will produce difficult to find deviations.

When an app is "launched" using RDKShell; the best intention is to set it to "visible" and "focused". This is handled by **luanch.rs** and **launch_with_content.rs**. Modified the logic of **get_state.rs** to check if app is "visible" assuming launcher logic remains same.