### PR TITLE
Update "frequency" fetch logic

### DIFF
--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -579,6 +579,19 @@ pub fn get_thunder_property(method_name: &str, key_name: &str) -> Result<String,
     }
 }
 
+pub fn get_frequency_from_displayinfo_framerate(framerate: &str) -> Result<f32, std::num::ParseFloatError> {
+    let framerate = framerate
+        .strip_prefix("Framerate")
+        .unwrap_or(framerate)
+        .replace("23976", "23.976")
+        .replace("2997", "29.97")
+        .replace("47952", "47.952")
+        .replace("5994", "59.94")
+        .replace("11988", "119.88");
+
+    framerate.parse::<f32>()
+}
+
 // ############################### APP Lifecycle Time Configs ###############################
 
 type TimeoutMap = HashMap<String, u64>;


### PR DESCRIPTION
Replace framerate fetch with best match - from DisplayInfo property instead of Framerate plugin because DisplayInfo is the mandatory and standard implementation requirement for SoC.

Supported possible framerate value from DisplayInfo.framerate property would be:
```
        "FramerateUnknown",
        "Framerate23976",
        "Framerate24",
        "Framerate25",
        "Framerate2997",
        "Framerate30",
        "Framerate47952",
        "Framerate48",
        "Framerate50",
        "Framerate5994",
        "Framerate60",
        "Framerate11988",
        "Framerate120",
        "Framerate144"
```
And get_frequency_from_displayinfo_framerate(in) would return the following for each:
```
test => in FramerateUnknown: out 60
test => in Framerate23976: out 23.976
test => in Framerate24: out 24
test => in Framerate25: out 25
test => in Framerate2997: out 29.97
test => in Framerate30: out 30
test => in Framerate47952: out 47.952
test => in Framerate48: out 48
test => in Framerate50: out 50
test => in Framerate5994: out 59.94
test => in Framerate60: out 60
test => in Framerate11988: out 119.88
test => in Framerate120: out 120
test => in Framerate144: out 144
```
Conformance Test:
```
d35@d35:~/Desktop/dab-compliance-suite$ dabSingleTest SystemSettingsGetConformance

testing system/settings/get   {} ... 
system/settings/get Latency, Expected: 800 ms, Actual: 746 ms

[ PASS ]
{
  "audioOutputMode": "Auto",
  "audioOutputSource": "HDMI",
  "audioVolume": 40,
  "cec": true,
  "hdrOutputMode": "AlwaysHdr",
  "language": "en-US",
  "lowLatencyMode": false,
  "matchContentFrameRate": "EnabledAlways",
  "memc": false,
  "mute": true,
  "outputResolution": {
    "frequency": 60.0,
    "height": 1080,
    "width": 1920
  },
  "pictureMode": "Standard",
  "status": 200,
  "textToSpeech": false,
  "videoInputSource": "Home"
}
```
DAB Adapter Logs:
```
d35@d35:~/Desktop/dab-works/dab-adapter-rs$ ./target/debug/dab-adapter -b $DIP -d $DIP --debug true
DAB<->RDK Adapter ("0.6.0" - "3e439da")
Using default values for app lifecycle timeouts.
youtube         - resume_launch_timeout_ms       =  3000ms.
youtube         - exit_to_destroy_timeout_ms     =  2500ms.
youtube         - cold_launch_timeout_ms         =  6000ms.
youtube         - exit_to_background_timeout_ms  =  2000ms.
RDK request: {"jsonrpc":"2.0","id":1,"method":"org.rdk.System.getDeviceInfo","params":{"params":["estb_mac"]}}
RDK response: {"jsonrpc":"2.0","id":1,"result":{"estb_mac":"02:AD:32:01:C8:35","success":true}}
DAB Device ID: 02AD3201C835
Ready to process DAB requests
processing: system/settings/get
RDK request: {"jsonrpc":"2.0","id":1,"method":"org.rdk.UserPreferences.1.getUILanguage"}
RDK response: {"jsonrpc":"2.0","id":1,"result":{"ui_language":"en-US","success":true}}
RDK request: {"jsonrpc":"2.0","id":1,"method":"DisplayInfo.width"}
RDK response: {"jsonrpc":"2.0","id":1,"result":1920}
RDK request: {"jsonrpc":"2.0","id":1,"method":"DisplayInfo.height"}
RDK response: {"jsonrpc":"2.0","id":1,"result":1080}
RDK request: {"jsonrpc":"2.0","id":1,"method":"DisplayInfo.framerate"}
RDK response: {"jsonrpc":"2.0","id":1,"result":"Framerate60"}
RDK request: {"jsonrpc":"2.0","id":2,"method":"org.rdk.DisplaySettings.getConnectedAudioPorts"}
RDK response: {"jsonrpc":"2.0","id":2,"result":{"connectedAudioPorts":["HDMI0","SPDIF0"],"success":true}}
RDK request: {"jsonrpc":"2.0","id":3,"method":"org.rdk.DisplaySettings.getVolumeLevel","params":{"audioPort":"HDMI0"}}
RDK response: {"jsonrpc":"2.0","id":3,"result":{"volumeLevel":"40.000000","success":true}}
RDK request: {"jsonrpc":"2.0","id":4,"method":"org.rdk.DisplaySettings.getConnectedAudioPorts"}
RDK response: {"jsonrpc":"2.0","id":4,"result":{"connectedAudioPorts":["HDMI0","SPDIF0"],"success":true}}
RDK request: {"jsonrpc":"2.0","id":5,"method":"org.rdk.DisplaySettings.getMuted","params":{"audioPort":"HDMI0"}}
RDK response: {"jsonrpc":"2.0","id":5,"result":{"muted":true,"success":true}}
RDK request: {"jsonrpc":"2.0","id":6,"method":"org.rdk.HdmiCec_2.getEnabled"}
RDK response: {"jsonrpc":"2.0","id":6,"result":{"enabled":true,"success":true}}
RDK request: {"jsonrpc":"2.0","id":7,"method":"org.rdk.DisplaySettings.getSettopHDRSupport"}
RDK response: {"jsonrpc":"2.0","id":7,"result":{"supportsHDR":true,"standards":["HDR10","HLG","Dolby Vision"],"success":true}}
RDK request: {"jsonrpc":"2.0","id":8,"method":"org.rdk.DisplaySettings.getTvHDRSupport"}
RDK response: {"jsonrpc":"2.0","id":8,"result":{"supportsHDR":true,"standards":["HDR10","HLG","Dolby Vision"],"success":true}}
RDK request: {"jsonrpc":"2.0","id":9,"method":"org.rdk.DisplaySettings.getConnectedAudioPorts"}
RDK response: {"jsonrpc":"2.0","id":9,"result":{"connectedAudioPorts":["HDMI0","SPDIF0"],"success":true}}
RDK request: {"jsonrpc":"2.0","id":10,"method":"org.rdk.DisplaySettings.getSoundMode","params":{"audioPort":"HDMI0"}}
RDK response: {"jsonrpc":"2.0","id":10,"result":{"soundMode":"AUTO (Dolby Digital Plus)","success":true}}
RDK request: {"jsonrpc":"2.0","id":11,"method":"org.rdk.DisplaySettings.getConnectedAudioPorts"}
RDK response: {"jsonrpc":"2.0","id":11,"result":{"connectedAudioPorts":["HDMI0","SPDIF0"],"success":true}}
RDK request: {"jsonrpc":"2.0","id":12,"method":"org.rdk.TextToSpeech.isttsenabled"}
RDK response: {"jsonrpc":"2.0","id":12,"result":{"isenabled":false,"TTS_Status":0,"success":true}}
Publishing response: dab/_response/system/settings/get {"audioOutputMode":"Auto","audioOutputSource":"HDMI","audioVolume":40,"cec":true,"hdrOutputMode":"AlwaysHdr","language":"en-US","lowLatencyMode":false,"matchContentFrameRate":"EnabledAlways","memc":false,"mute":true,"outputResolution":{"frequency":60.0,"height":1080,"width":1920},"pictureMode":"Standard","status":200,"textToSpeech":false,"videoInputSource":"Home"}
```