### PR TITLE
feat: updating hdmicec plugin configuration #64

### DIFF
--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -176,7 +176,7 @@ pub fn process(_dab_request: ListSystemSettingsRequest) -> Result<String, DabErr
 
     ResponseOperator.memc = false;
 
-    ResponseOperator.cec = service_is_available("org.rdk.HdmiCec_2")?;
+    ResponseOperator.cec = service_is_available("org.rdk.HdmiCecSource")?;
 
     ResponseOperator.lowLatencyMode = false;
 

--- a/src/device/rdk/system/settings/set.rs
+++ b/src/device/rdk/system/settings/set.rs
@@ -119,7 +119,7 @@ fn set_rdk_cec(enabled: bool) -> Result<(), DabError> {
     let req_params = Param { enabled };
 
     let _rdkresponse: RdkResponseSimple =
-        rdk_request_with_params("org.rdk.HdmiCec_2.setEnabled", req_params)?;
+        rdk_request_with_params("org.rdk.HdmiCecSource.setEnabled", req_params)?;
 
     Ok(())
 }


### PR DESCRIPTION
HdmiCec_2 plugin has been deprecated in rdkv stack. and replaced by the HdmiCecSource plugin
HdmiCecSource will not be enabled by default.