### PR TITLE
BCM-1152: Updating Supported audioOutputSource List.

### DIFF
--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -106,6 +106,8 @@ pub fn get_rdk_supported_audio_source() -> Result<Vec<AudioOutputSource>, DabErr
         let val = match source.as_str() {
             "SPDIF0" => AudioOutputSource::Optical,
             "HDMI0" => AudioOutputSource::HDMI,
+            "IDLR0" => AudioOutputSource::Aux,
+            "SPEAKER0" => AudioOutputSource::NativeSpeaker,
             _ => {
                 continue;
             }


### PR DESCRIPTION
Reason for change: some platform supports multiple audioport hence updating list. "IDLR0" => Aux,"SPEAKER0" => NativeSpeaker.
Test Procedure: build,flash image and verify DAB settings/list operation .
Risks: Medium.