### PR TITLE
[PREMIUMAPP-3286] Introduce support for multiple UI languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ To configure dab-adapter, for example set a list of supported languages, a confi
 }
 ```
 
+If `supported_languages` field is not provided, or if the deserialization of settings fails, `supported_languagess` falls back to `en-US`.
+
 ## Device ID ##
 
 In this implementation for RDK, the Device ID as specified by DAB is given by the `org.rdk.System.getDeviceInfo`` method of [RDK plugin](https://rdkcentral.github.io/rdkservices/#/api/SystemPlugin).

--- a/README.md
+++ b/README.md
@@ -73,6 +73,16 @@ OPTIONS:
     -v, --version               Print the version information
 ```
 
+### Settings ###
+
+To configure dab-adapter, for example set a list of supported languages, a configuration file `/etc/dab/settings.json` can be used, with the following structure:
+
+```json
+{
+  "supported_languages": ["en-US", "es-US"]
+}
+```
+
 ## Device ID ##
 
 In this implementation for RDK, the Device ID as specified by DAB is given by the `org.rdk.System.getDeviceInfo`` method of [RDK plugin](https://rdkcentral.github.io/rdkservices/#/api/SystemPlugin).

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To configure dab-adapter, for example set a list of supported languages, a confi
 }
 ```
 
-If `supported_languages` field is not provided, or if the deserialization of settings fails, `supported_languagess` falls back to `en-US`.
+It must be in a form of an array of RFC 5646 language tags. If `supported_languages` field is not provided, or if the deserialization of settings fails, `supported_languagess` falls back to `en-US`.
 
 ## Device ID ##
 

--- a/src/device/rdk/applications/launch.rs
+++ b/src/device/rdk/applications/launch.rs
@@ -3,6 +3,7 @@ use crate::dab::structs::LaunchApplicationRequest;
 use crate::device::rdk::applications::get_state::get_dab_app_state;
 use crate::device::rdk::interface::http_post;
 use crate::device::rdk::interface::get_lifecycle_timeout;
+use crate::device::rdk::system::settings::get::get_rdk_language;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -62,7 +63,8 @@ pub fn process(_dab_request: LaunchApplicationRequest) -> Result<String, DabErro
             // Cold launch of app.
             let req_params = if is_cobalt {
                 let url = format!("https://www.youtube.com/tv?{}", param_list.join("&"));
-                let config = json!({"url": url});
+                let language = get_rdk_language().unwrap();
+                let config = json!({"url": url, "language": language});
                 RDKShellParams {
                     callsign: _dab_request.appId.clone(),
                     r#type: "Cobalt".into(),

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -385,6 +385,32 @@ pub fn service_is_available(service: &str) -> Result<bool, DabError> {
     }
 */
 
+
+lazy_static! {
+    static ref SUPPORTED_LANGUAGES: Vec<String> = {
+
+        #[derive(Deserialize, Debug)]
+        struct Settings {
+            supported_languages: Vec<String>,
+        }
+
+        if let Ok(json_file) = read_platform_config_json("/etc/dab/settings.json") {
+            match serde_json::from_str::<Settings>(&json_file) {
+                Ok(json_object) => {
+                    println!("Loaded supported languages from /etc/dab/settings.json");
+                    return json_object.supported_languages;
+                }
+                Err(error) => {
+                    eprintln!("Error while parsing /etc/dab/settings.json: {}", error);
+                }
+            }
+        }
+
+        println!("Falling back to default supported language: en-US");
+        vec![String::from("en-US")]
+    };
+}
+
 lazy_static! {
     static ref RDK_KEYMAP: HashMap<String, u16> = {
         let mut keycode_map = HashMap::new();
@@ -689,4 +715,8 @@ pub fn get_lifecycle_timeout(app_name: &str, timeout_type: &str) -> Option<u64> 
         .and_then(|timeouts| timeouts.get(timeout_type))
         .cloned()
         .or_else(|| Some(2500))
+}
+
+pub fn get_supported_languages() -> Vec<String> {
+    SUPPORTED_LANGUAGES.clone()
 }

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -389,7 +389,7 @@ pub fn service_is_available(service: &str) -> Result<bool, DabError> {
 // instead of having them in different files and in /opt
 #[derive(Deserialize, Debug)]
 struct Settings {
-    supported_languages: Vec<String>,
+    supported_languages: Option<Vec<String>>,
 }
 
 lazy_static! {
@@ -399,7 +399,7 @@ lazy_static! {
         if let Ok(json_file) = read_platform_config_json(config_path) {
             match serde_json::from_str::<Settings>(&json_file) {
                 Ok(json_object) => {
-                    println!("Loaded settings from: {}", config_path);
+                    println!("Loaded settings: {:?} from: {}", json_object, config_path);
                     return json_object
                 }
                 Err(error) => {
@@ -407,9 +407,10 @@ lazy_static! {
                 }
             }
         }
-        println!("Using default settings, with supported languages: [en-US]");
+
+        println!("Using default settings.");
         Settings {
-            supported_languages: vec![String::from("en-US")],
+            supported_languages: None,
         }
 
     };
@@ -722,5 +723,8 @@ pub fn get_lifecycle_timeout(app_name: &str, timeout_type: &str) -> Option<u64> 
 }
 
 pub fn get_supported_languages() -> Vec<String> {
-    SETTINGS.supported_languages.clone()
+    SETTINGS.supported_languages.clone().unwrap_or_else(|| {
+        println!("Falling back to en-US as supported language.");
+        vec![String::from("en-US")]
+    })
 }

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -723,8 +723,8 @@ pub fn get_lifecycle_timeout(app_name: &str, timeout_type: &str) -> Option<u64> 
 }
 
 pub fn get_supported_languages() -> Vec<String> {
-    SETTINGS.supported_languages.clone().unwrap_or_else(|| {
-        println!("Falling back to en-US as supported language.");
-        vec![String::from("en-US")]
-    })
+    SETTINGS
+        .supported_languages
+        .clone()
+        .unwrap_or_else(|| vec![String::from("en-US")])
 }

--- a/src/device/rdk/system/settings/get.rs
+++ b/src/device/rdk/system/settings/get.rs
@@ -17,7 +17,7 @@ use crate::hw_specific::interface::get_service_state;
 use crate::hw_specific::interface::service_activate;
 use serde::{Deserialize, Serialize};
 
-fn get_rdk_language() -> Result<String, DabError> {
+pub fn get_rdk_language() -> Result<String, DabError> {
     #[allow(dead_code)]
     #[derive(Deserialize)]
     struct GetUILanguage {

--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -14,6 +14,7 @@ use crate::device::rdk::interface::rdk_sound_mode_to_dab;
 use crate::device::rdk::interface::service_is_available;
 use crate::device::rdk::interface::RdkResponse;
 use crate::device::rdk::system::settings::get::get_rdk_audio_port;
+use crate::hw_specific::interface::get_supported_languages;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 
@@ -183,7 +184,7 @@ pub fn process(_dab_request: ListSystemSettingsRequest) -> Result<String, DabErr
     //     "The language is written to the /opt/user_preferences.conf file on the device.
     //     It is the responsibility of the client application to validate the language value and process
     //     it if required. Any language string that is valid on the client can be set"
-    ResponseOperator.language = vec!["en-US".to_string()];
+    ResponseOperator.language = get_supported_languages();
 
     ResponseOperator.outputResolution = get_rdk_resolutions()?;
 


### PR DESCRIPTION
The goal of this PR is to:
- enable YTS test cases that rely on multiple languages,
- for Cobalt, start the application with chosen UI language.

To achieve this, instead of having hard-coded language code in `src/device/rdk/system/settings/list.rs`, allow user to create a configuration file in `/etc/dab/settings.json` where a list of supported languages might be provided (using en-US if not found or failed to parse).  For starting a Cobalt application with proper language, during launch command a call to UserPreferences is issued, to retrieve currently used language. That language is later used in `language` parameter for Cobalt application. 

Configuration file, with a support for two languages could look like following:
```
{
  "supported_languages": ["en-US", "es-US"]
}
```