### PR TITLE
PREMIUMAPP-3387: Check for empty VA to return 400 and avoid initializing not supported VA

### DIFF
--- a/src/dab/structs.rs
+++ b/src/dab/structs.rs
@@ -243,6 +243,7 @@ pub struct VoiceSystem {
 #[derive(Default, Serialize, Deserialize)]
 pub struct SendAudioRequest {
     pub fileLocation: String,
+    pub voiceSystem: String,
 }
 
 #[allow(non_snake_case)]

--- a/src/device/rdk/voice/send_audio.rs
+++ b/src/device/rdk/voice/send_audio.rs
@@ -7,6 +7,10 @@ use crate::device::rdk::interface::http_download;
 #[allow(dead_code)]
 #[allow(unused_mut)]
 pub fn process(_dab_request: SendAudioRequest) -> Result<String, DabError> {
+    if _dab_request.voiceSystem.to_string() != "AmazonAlexa" || _dab_request.voiceSystem.to_string().is_empty() {
+        return Err(DabError::Err400("Unsupported 'voiceSystem'.".to_string()));
+    }
+
     http_download(_dab_request.fileLocation)?;
     sendVoiceCommand("/tmp/tts.wav".into())?;
     Ok("{}".to_string())

--- a/src/device/rdk/voice/send_text.rs
+++ b/src/device/rdk/voice/send_text.rs
@@ -14,7 +14,7 @@ use urlencoding::encode;
 #[allow(unused_mut)]
 pub fn process(_dab_request: SendTextRequest) -> Result<String, DabError> {
     // TODO: Add other RDK specific voice protocol support confirmation.
-    if _dab_request.voiceSystem.to_string() != "AmazonAlexa" {
+    if _dab_request.voiceSystem.to_string() != "AmazonAlexa" || _dab_request.voiceSystem.to_string().is_empty() {
         return Err(DabError::Err400("Unsupported 'voiceSystem'.".to_string()));
     }
 

--- a/src/device/rdk/voice/set.rs
+++ b/src/device/rdk/voice/set.rs
@@ -10,7 +10,7 @@ pub fn process(_dab_request: SetVoiceSystemRequest) -> Result<String, DabError> 
     let mut ResponseOperator = SetVoiceSystemResponse::default();
 
     // TODO: Add other RDK specific voice protocol support confirmation.
-    if _dab_request.voiceSystem.name != "AmazonAlexa" {
+    if _dab_request.voiceSystem.name != "AmazonAlexa" || _dab_request.voiceSystem.name.is_empty() {
         // Unsupported VoiceSystem.
         return Err(DabError::Err400(
             "Setting voiceSystem failed. Unsupported voiceSystem.".to_string(),


### PR DESCRIPTION
When VA is not supported by the platform, and the VA is set to "" in compliance-suite tool, it is sending requests with:  `"voiceSystem": ""`. In that  case, fail-fast with 400 status code nad avoid initialization of misconfigured voice system.