### PR TITLE
PREMIUMAPP-3429: Add audio_volume_range setting and runtime check is value is within range

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,26 @@ OPTIONS:
 
 ### Settings ###
 
-To configure dab-adapter, for example set a list of supported languages, a configuration file `/etc/dab/settings.json` can be used, with the following structure:
+To configure dab-adapter a configuration file `/etc/dab/settings.json` can be used, with the following structure:
 
 ```json
 {
-  "supported_languages": ["en-US", "es-US"]
+    "supported_languages": ["en-US", "es-US"],
+    "audio_volume_range": {
+     "max": 110,
+     "min": 50
+    }
 }
 ```
 
-It must be in a form of an array of RFC 5646 language tags. If `supported_languages` field is not provided, or if the deserialization of settings fails, `supported_languagess` falls back to `en-US`.
+#### Available settings ####
+
+1. `supported_languages`
+It must be in a form of an array of RFC 5646 language tags. If this field is not provided, or if the deserialization of settings fails, `supported_languagess` falls back to `en-US`.
+
+2. `audio_volume_range`
+It is a object with `min` and `max` fields. This is used to indicate possible audio volume range. If this field is not provided, or if the deserialization of settings fails, `audio_volume_range` falls back to `{min: 0, max: 100}`.
+
 
 ## Device ID ##
 

--- a/src/dab/structs.rs
+++ b/src/dab/structs.rs
@@ -333,7 +333,7 @@ pub enum VideoInputSource {
 }
 
 #[allow(non_snake_case)]
-#[derive(Default, Serialize, Deserialize)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 pub struct AudioVolume {
     pub min: u32,
     pub max: u32,

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -1,4 +1,5 @@
 use crate::dab::structs::AudioOutputMode;
+use crate::dab::structs::AudioVolume;
 use crate::dab::structs::DabError;
 use futures::executor::block_on;
 use futures_util::stream::StreamExt;
@@ -390,6 +391,7 @@ pub fn service_is_available(service: &str) -> Result<bool, DabError> {
 #[derive(Deserialize, Debug)]
 struct Settings {
     supported_languages: Option<Vec<String>>,
+    audio_volume_range: Option<AudioVolume>
 }
 
 lazy_static! {
@@ -411,6 +413,7 @@ lazy_static! {
         println!("Using default settings.");
         Settings {
             supported_languages: None,
+            audio_volume_range: None
         }
 
     };
@@ -733,4 +736,11 @@ pub fn get_supported_languages() -> Vec<String> {
         .supported_languages
         .clone()
         .unwrap_or_else(|| vec![String::from("en-US")])
+}
+
+pub fn get_audio_volume_range() -> AudioVolume {
+    SETTINGS
+        .audio_volume_range
+        .clone()
+        .unwrap_or_else(|| AudioVolume { min: 0, max: 100 })
 }

--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -14,6 +14,7 @@ use crate::device::rdk::interface::rdk_sound_mode_to_dab;
 use crate::device::rdk::interface::service_is_available;
 use crate::device::rdk::interface::RdkResponse;
 use crate::device::rdk::system::settings::get::get_rdk_audio_port;
+use crate::hw_specific::interface::get_audio_volume_range;
 use crate::hw_specific::interface::get_supported_languages;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
@@ -200,7 +201,7 @@ pub fn process(_dab_request: ListSystemSettingsRequest) -> Result<String, DabErr
 
     ResponseOperator.hdrOutputMode = get_rdk_hdr_settings()?;
 
-    ResponseOperator.audioVolume = AudioVolume { min: 0, max: 100 };
+    ResponseOperator.audioVolume = get_audio_volume_range();
 
     ResponseOperator.matchContentFrameRate = vec![
         MatchContentFrameRate::EnabledAlways,

--- a/src/device/rdk/system/settings/set.rs
+++ b/src/device/rdk/system/settings/set.rs
@@ -11,6 +11,7 @@ use crate::device::rdk::system::settings::get::get_rdk_audio_port;
 use crate::device::rdk::system::settings::get::get_rdk_hdr_current_setting;
 use crate::device::rdk::system::settings::list::get_rdk_hdr_settings;
 use crate::device::rdk::system::settings::list::get_rdk_supported_audio_modes;
+use crate::hw_specific::interface::get_audio_volume_range;
 use crate::hw_specific::system::settings::get::get_rdk_connected_video_displays;
 
 use serde::{Deserialize, Serialize};
@@ -75,6 +76,12 @@ fn set_rdk_resolution(resolution: &OutputResolution) -> Result<(), DabError> {
 }
 
 fn set_rdk_audio_volume(volume: u32) -> Result<(), DabError> {
+
+    let range = get_audio_volume_range();
+    if !(range.min..=range.max).contains(&volume) {
+        return Err(DabError::Err400("Unsupported audio volume value".to_string()))
+    }
+
     #[allow(non_snake_case)]
     #[derive(Serialize)]
     struct Param {


### PR DESCRIPTION
This allows passing NEGATIVE_TEST in compliance-suite regarding invalid audio volume.