### PR TITLE
RDKEAPPRT-108: Enable input/long-key-press in operations/list output

### DIFF
--- a/src/device/rdk/operations/list.rs
+++ b/src/device/rdk/operations/list.rs
@@ -46,9 +46,9 @@ pub fn process(_dab_request: OperationsListRequest) -> Result<String, DabError> 
     ResponseOperator
         .operations
         .push("input/key-press".to_string());
-    // ResponseOperator
-    //     .operations
-    //     .push("input/long-key-press".to_string());
+    ResponseOperator
+        .operations
+        .push("input/long-key-press".to_string());
     ResponseOperator.operations.push("output/image".to_string());
     // ResponseOperator
     //     .operations


### PR DESCRIPTION
This API was tested by dab-compliance-suite previously, although it was not in the operations/list. On latest compliance-suite: c77884c7a1a516e43c6e8ed057508121f8f368dc this value is actually checked and taken into account.