### PR TITLE
feat: use version 3 of cargo-lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -735,7 +735,7 @@ dependencies = [
 
 [[package]]
 name = "dab-adapter"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
  "async-std",
  "base64 0.21.7",


### PR DESCRIPTION
Version 4 of cargo-lock is not supported in RDK rust toolchain. dab-adapter component version is left as 0.7.0 in the cargo-lock.

This is a back port of: https://github.com/device-automation-bus/dab-adapter-rs/pull/88