### PR TITLE
feat: use UserSettings as platform lang source. Do not unwrap on failed get_language.

### DIFF
--- a/src/device/rdk/applications/launch.rs
+++ b/src/device/rdk/applications/launch.rs
@@ -6,6 +6,7 @@ use crate::device::rdk::applications::get_state::get_dab_app_state;
 use crate::device::rdk::interface::http_post;
 use crate::device::rdk::interface::get_lifecycle_timeout;
 use crate::device::rdk::system::settings::get::get_rdk_language;
+use crate::hw_specific::interface::get_default_langauge;
 use serde::{Deserialize, Serialize};
 use serde_json::json;
 
@@ -82,7 +83,10 @@ pub fn process(_dab_request: LaunchApplicationRequest) -> Result<String, DabErro
             // Cold launch of app.
             let req_params = if is_cobalt {
                 let url = format!("https://www.youtube.com/tv?{}", param_list.join("&"));
-                let language = get_rdk_language().unwrap();
+                let language = get_rdk_language().map_err(|err|{
+                    eprintln!("Unable to retrieve RDK language.");
+                    err
+                })?;
                 let config = json!({"url": url, "language": language});
                 RDKShellParams {
                     callsign: _dab_request.appId.clone(),

--- a/src/device/rdk/system/settings/get.rs
+++ b/src/device/rdk/system/settings/get.rs
@@ -18,17 +18,10 @@ use crate::hw_specific::interface::service_activate;
 use serde::{Deserialize, Serialize};
 
 pub fn get_rdk_language() -> Result<String, DabError> {
-    #[allow(dead_code)]
-    #[derive(Deserialize)]
-    struct GetUILanguage {
-        ui_language: String,
-        success: bool,
-    }
+    let rdkresponse: RdkResponse<String> =
+        rdk_request("org.rdk.UserSettings.getPresentationLanguage")?;
 
-    let rdkresponse: RdkResponse<GetUILanguage> =
-        rdk_request("org.rdk.UserPreferences.1.getUILanguage")?;
-
-    Ok(rdkresponse.result.ui_language)
+    Ok(rdkresponse.result)
 }
 
 fn get_frequency_from_displayinfo_framerate(

--- a/src/device/rdk/system/settings/list.rs
+++ b/src/device/rdk/system/settings/list.rs
@@ -178,13 +178,6 @@ pub fn process(_dab_request: ListSystemSettingsRequest) -> Result<String, DabErr
     let mut ResponseOperator = ListSystemSettingsResponse::default();
     // *** Fill in the fields of the struct ListSystemSettings here ***
 
-    // // Return language tags defined in RFC 5646.
-    // /*
-    //     IMPORTANT NOTE: As defined on the org.rdk.UserPreferences plugin documentation
-    //     (https://rdkcentral.github.io/rdkservices/#/api/UserPreferencesPlugin):
-    //     "The language is written to the /opt/user_preferences.conf file on the device.
-    //     It is the responsibility of the client application to validate the language value and process
-    //     it if required. Any language string that is valid on the client can be set"
     ResponseOperator.language = get_supported_languages();
 
     ResponseOperator.outputResolution = get_rdk_resolutions()?;

--- a/src/device/rdk/system/settings/set.rs
+++ b/src/device/rdk/system/settings/set.rs
@@ -11,6 +11,7 @@ use crate::device::rdk::system::settings::get::get_rdk_audio_port;
 use crate::device::rdk::system::settings::get::get_rdk_hdr_current_setting;
 use crate::device::rdk::system::settings::list::get_rdk_hdr_settings;
 use crate::device::rdk::system::settings::list::get_rdk_supported_audio_modes;
+use crate::hw_specific::interface::RdkResponse;
 use crate::hw_specific::interface::get_audio_volume_range;
 use crate::hw_specific::system::settings::get::get_rdk_connected_video_displays;
 
@@ -21,16 +22,23 @@ use std::collections::HashMap;
 
 fn set_rdk_language(language: String) -> Result<(), DabError> {
     #[derive(Serialize)]
+    #[allow(non_snake_case)]
     struct Param {
-        ui_language: String,
+        presentationLanguage: String,
     }
 
-    let _rdkresponse: RdkResponseSimple = rdk_request_with_params(
-        "org.rdk.UserPreferences.1.setUILanguage",
+    let rdkresponse: RdkResponse<Option<String>> = rdk_request_with_params(
+        "org.rdk.UserSettings.setPresentationLanguage",
         Param {
-            ui_language: language,
+            presentationLanguage: language,
         },
     )?;
+
+    if let Some(msg) = rdkresponse.result {
+        return Err(DabError::Err500(
+            format!("Error from org.rdk.UserSettings.setPresentationLanguage {}", msg),
+        ));
+    }
 
     Ok(())
 }


### PR DESCRIPTION
Use UserSettings instead of UserPreferences for platform language
source. Do not use unwrap in launch API that can cause dab-adapter
crash.

Ref: #RDKEAPPRT-329