### PR TITLE
Fix build errors for armv7 target

### DIFF
--- a/src/device/rdk/device/info.rs
+++ b/src/device/rdk/device/info.rs
@@ -10,6 +10,7 @@ use crate::device::rdk::interface::get_device_id;
 use crate::device::rdk::interface::http_post;
 use crate::device::rdk::interface::{get_rdk_device_info, get_thunder_property};
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 
 #[allow(non_snake_case)]
 #[allow(dead_code)]

--- a/src/device/rdk/interface.rs
+++ b/src/device/rdk/interface.rs
@@ -104,9 +104,7 @@ pub fn init(device_ip: &str, debug: bool) {
 }
 
 pub fn is_local_device() -> bool {
-    // `DEVICE_ADDRESS` is a mutable static `String`, so treat it as a plain
-    // string slice here rather than using any container-style `get()`.
-    let addr = unsafe { DEVICE_ADDRESS.as_str() };
+    let addr = DEVICE_ADDRESS.get().map(|s| s.as_str()).unwrap_or("");
     matches!(addr, "localhost" | "127.0.0.1" | "::1")
 }
 


### PR DESCRIPTION
- Add missing `use serde_json::Value` import in device/info.rs
- Fix `DEVICE_ADDRESS.as_str()` call in interface.rs: OnceLock does not have as_str(); use .get().map(|s| s.as_str()).unwrap_or("") instead, removing the unnecessary unsafe block