### PR TITLE
input/keypress: Re-enable KEY_FAST_FORWARD handling

### DIFF
--- a/src/device/rdk/input/key_press.rs
+++ b/src/device/rdk/input/key_press.rs
@@ -36,7 +36,6 @@ pub fn process(_dab_request: KeyPressRequest) -> Result<String, DabError> {
             let current_mute = get_rdk_mute().unwrap_or(false);
             let _ = set_rdk_mute(!current_mute);
         }
-        "KEY_FAST_FORWARD" => return Err(DabError::Err400("'KEY_FAST_FORWARD' not supported".to_string())),
         _ => {}
     }
 


### PR DESCRIPTION
- Remove explicit Err400 for KEY_FAST_FORWARD
- Fall back to normal injection path for mapping 223
- Requires RDK UI 4.5.9+

See Cobalt's b/485675444 for more information.