### PR TITLE
system/language: handle empty presentationLanguage on older RDK images

### DIFF
--- a/src/device/rdk/applications/launch.rs
+++ b/src/device/rdk/applications/launch.rs
@@ -82,11 +82,19 @@ pub fn process(_dab_request: LaunchApplicationRequest) -> Result<String, DabErro
             // Cold launch of app.
             let req_params = if is_cobalt {
                 let url = format!("https://www.youtube.com/tv?{}", param_list.join("&"));
-                let language = get_rdk_language().map_err(|err|{
-                    eprintln!("Unable to retrieve RDK language.");
-                    err
-                })?;
-                let config = json!({"url": url, "language": language});
+                // The language is optional; do not abort the launch if the
+                // lookup fails, just launch without it.
+                let language = get_rdk_language().unwrap_or_else(|err| {
+                    eprintln!("Unable to retrieve RDK language: {:?}", err);
+                    String::new()
+                });
+                // An empty presentationLanguage would make the Cobalt plugin set
+                // LANG="" (C locale, navigator.language == "c"); omit it instead.
+                let config = if language.is_empty() {
+                    json!({"url": url})
+                } else {
+                    json!({"url": url, "language": language})
+                };
                 RDKShellParams {
                     callsign: _dab_request.appId.clone(),
                     r#type: "Cobalt".into(),

--- a/src/device/rdk/system/settings/get.rs
+++ b/src/device/rdk/system/settings/get.rs
@@ -38,11 +38,49 @@ fn get_rdk_video_input_source() -> VideoInputSource {
         .unwrap_or(VideoInputSource::Home)
 }
 
+const DEFAULT_LANGUAGE: &str = "en-US";
+
 pub fn get_rdk_language() -> Result<String, DabError> {
     let rdkresponse: RdkResponse<String> =
         rdk_request("org.rdk.UserSettings.getPresentationLanguage")?;
 
-    Ok(rdkresponse.result)
+    if !rdkresponse.result.is_empty() {
+        return Ok(rdkresponse.result);
+    }
+
+    // Some images ship a settings UI that stores the language only in
+    // org.rdk.UserPreferences (ui_language in /opt/user_preferences.conf)
+    // without forwarding it to UserSettings, leaving presentationLanguage
+    // empty. Fall back to the UI language in that case. The fallback is
+    // best-effort: on any error return the default language.
+    #[derive(Deserialize)]
+    struct GetUILanguage {
+        ui_language: String,
+    }
+
+    match get_service_state("org.rdk.UserPreferences") {
+        Ok(state) => {
+            if state != "activated" {
+                if let Err(e) = service_activate("org.rdk.UserPreferences".to_string()) {
+                    println!("RDK error: {:?}", e);
+                    return Ok(DEFAULT_LANGUAGE.to_string());
+                }
+            }
+        }
+        Err(e) => {
+            println!("RDK error: {:?}", e);
+            return Ok(DEFAULT_LANGUAGE.to_string());
+        }
+    }
+
+    match rdk_request::<RdkResponse<GetUILanguage>>("org.rdk.UserPreferences.getUILanguage") {
+        Ok(uipref) if !uipref.result.ui_language.is_empty() => Ok(uipref.result.ui_language),
+        Ok(_) => Ok(DEFAULT_LANGUAGE.to_string()),
+        Err(e) => {
+            println!("RDK error: {:?}", e);
+            Ok(DEFAULT_LANGUAGE.to_string())
+        }
+    }
 }
 
 fn get_frequency_from_displayinfo_framerate(


### PR DESCRIPTION
`UserSettings.getPresentationLanguage` returns `""` on images whose settings UI stores the language only in UserPreferences. Cobalt then gets `configuration.language` equals `""`, then sets `LANG=""`, and `navigator.language` reports `"c"`, failing the YTS "Settings Language" test.

Fall back to `UserPreferences.getUILanguage`, then to `"en-US"` when no language is stored at all, as on a freshly flashed image where `/opt/user_preferences.conf` does not exist. On launch, omit the field when the language is still empty so RDKShell keeps the persisted value.
